### PR TITLE
fix: retposto vidi UUID prefix support + fix wrong-table CRUDService bug (#23)

### DIFF
--- a/src/A_lien/cli/retposto.py
+++ b/src/A_lien/cli/retposto.py
@@ -16,6 +16,52 @@ from A import error, info, tr_multi, warning
 from A_lien.imap import IMAPClient
 from A_lien.service import get_retposto_service
 
+
+def _resolve_message(svc: Any, prefix: str) -> dict[str, Any]:
+    """Resolve a message by exact UUID or unique prefix.
+
+    Tries exact match first, then prefix lookup.
+    Handles 0 matches (not found) and multiple (ambiguous).
+
+    Args:
+        svc: RetpostoService instance
+        prefix: UUID or UUID prefix
+
+    Returns:
+        Message dict
+
+    Raises:
+        typer.Exit(1) if not found or ambiguous
+    """
+    # Exact match first
+    msg = svc.get_message(prefix)
+    if msg:
+        return msg
+
+    # Prefix fallback
+    matches = svc.find_message_by_uuid_prefix(prefix)
+
+    if len(matches) == 1:
+        return matches[0]
+
+    if len(matches) > 1:
+        error(tr_multi(
+            f"Pluraj mesaĝoj kongruas kun '{prefix}':",
+            f"Multiple messages match '{prefix}':",
+            f"Plusieurs messages correspondent à '{prefix}':",
+        ))
+        for m in matches:
+            subj = (m.get("subjekto", "") or "(sen temo)")[:50]
+            info(f"  {m['uuid'][:8]}  {subj}")
+        raise typer.Exit(1)
+
+    error(tr_multi(
+        f"Mesaĝo ne trovita: {prefix}",
+        f"Message not found: {prefix}",
+        f"Message non trouvé: {prefix}",
+    ))
+    raise typer.Exit(1)
+
 retposto = typer.Typer(
     name="retposto",
     help=tr_multi(
@@ -228,17 +274,9 @@ def retposto_vidi_mesago(
         help=tr_multi("Montri HTML", "Show HTML", "Afficher HTML"),
     ),
 ) -> None:
-    """View a email by UUID (opens in editor by default)."""
+    """View a email by UUID or prefix (opens in editor by default)."""
     svc = get_retposto_service()
-    msg = svc.get_message(uuid)
-
-    if not msg:
-        error(tr_multi(
-            f"Mesaĝo ne trovita: {uuid}",
-            f"Message not found: {uuid}",
-            f"Message non trouvé: {uuid}",
-        ))
-        raise typer.Exit(1)
+    msg = _resolve_message(svc, uuid)
 
     # Build email text
     lines = [

--- a/src/A_lien/service/retposto_contact_mixin.py
+++ b/src/A_lien/service/retposto_contact_mixin.py
@@ -1,0 +1,79 @@
+"""Contact auto-creation mixin for RetpostoService.
+
+Handles automatic contact creation from email senders and recipients
+during IMAP sync and SMTP send operations.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from A_lien.imap import (
+    should_autosave_contact,
+    _parse_email_address,
+    _extract_sender_name,
+)
+from A_lien.service.kontakto_service import get_kontakto_service
+
+
+class RetpostoContactMixin:
+    """Mixin providing auto-contact creation for RetpostoService.
+
+    Requires self.db and the ability to call get_kontakto_service().
+    """
+
+    def _upsert_contact_from_email(
+        self, email_addr: str, display_name: str = "",
+    ) -> None:
+        """Create or update a contact from an email address.
+
+        Skips no-reply / temporary addresses.
+        If a contact with this email already exists, updates the name.
+        Otherwise creates a new contact.
+
+        Args:
+            email_addr: Raw From header (e.g. 'Name <addr@dom.ain>')
+            display_name: Optional display name
+        """
+        addr = _parse_email_address(email_addr)
+        if not addr or not should_autosave_contact(email_addr):
+            return
+
+        kontakto = get_kontakto_service()
+        name = display_name or _extract_sender_name(email_addr) or addr.split("@")[0]
+
+        existing = kontakto.find_by_email(addr)
+        if existing:
+            if name and not existing.get("plena_nomo"):
+                kontakto.update(existing["uuid"], {"plena_nomo": name})
+        else:
+            kontakto.create({
+                "plena_nomo": name,
+                "retposhtadresoj": json.dumps(
+                    [{"valoro": addr}],
+                    ensure_ascii=False,
+                ),
+            })
+
+    def _autosave_sync_contacts(self, konto_id: str) -> None:
+        """Auto-create contacts from senders of newly synced, unseen messages.
+
+        Args:
+            konto_id: Account UUID whose messages to scan
+        """
+        rows = self.db.execute(
+            """SELECT de FROM mesagxoj
+               WHERE konto_id = ? AND legita = 0
+               ORDER BY ricevita_je DESC LIMIT 100""",
+            (konto_id,),
+        )
+        seen = set()
+        for row in rows:
+            sender = (row.get("de") or "").strip()
+            if sender and sender not in seen:
+                seen.add(sender)
+                self._upsert_contact_from_email(sender)
+
+
+__all__ = ["RetpostoContactMixin"]

--- a/src/A_lien/service/retposto_service.py
+++ b/src/A_lien/service/retposto_service.py
@@ -25,12 +25,13 @@ from A_lien.keyring import get_password as _get_keyring_pw
 from A_lien.keyring import set_password as _set_keyring_pw
 from A_lien.keyring import delete_password as _del_keyring_pw
 from A_lien.service.kontakto_service import get_kontakto_service
+from A_lien.service.retposto_contact_mixin import RetpostoContactMixin
 from A_lien.service.retposto_signature import RetpostoSignatureMixin
 
 _retposto_service: RetpostoService | None = None
 
 
-class RetpostoService(CRUDService, MessageStore, RetpostoSignatureMixin):
+class RetpostoService(CRUDService, MessageStore, RetpostoSignatureMixin, RetpostoContactMixin):
     """Email account management with keyring password storage.
 
     Features:
@@ -111,60 +112,7 @@ class RetpostoService(CRUDService, MessageStore, RetpostoSignatureMixin):
         )
         return msg_uuid
 
-    # ── Auto-contact helpers ──────────────────────────────────────────────────
-
-    def _upsert_contact_from_email(
-        self, email_addr: str, display_name: str = "",
-    ) -> None:
-        """Create or update a contact from an email address.
-
-        Skips no-reply / temporary addresses.
-        If a contact with this email already exists, updates the name.
-        Otherwise creates a new contact.
-
-        Args:
-            email_addr: Raw From header (e.g. 'Name <addr@dom.ain>')
-            display_name: Optional display name
-        """
-        addr = _parse_email_address(email_addr)
-        if not addr or not should_autosave_contact(email_addr):
-            return
-
-        kontakto = get_kontakto_service()
-        name = display_name or _extract_sender_name(email_addr) or addr.split("@")[0]
-
-        existing = kontakto.find_by_email(addr)
-        if existing:
-            # Update name if we have one and contact doesn't have a full name
-            if name and not existing.get("plena_nomo"):
-                kontakto.update(existing["uuid"], {"plena_nomo": name})
-        else:
-            kontakto.create({
-                "plena_nomo": name,
-                "retposhtadresoj": json.dumps(
-                    [{"valoro": addr}],
-                    ensure_ascii=False,
-                ),
-            })
-
-    def _autosave_sync_contacts(self, konto_id: str) -> None:
-        """Auto-create contacts from senders of newly synced, unseen messages.
-
-        Args:
-            konto_id: Account UUID whose messages to scan
-        """
-        rows = self.db.execute(
-            """SELECT de FROM mesagxoj
-               WHERE konto_id = ? AND legita = 0
-               ORDER BY ricevita_je DESC LIMIT 100""",
-            (konto_id,),
-        )
-        seen = set()
-        for row in rows:
-            sender = (row.get("de") or "").strip()
-            if sender and sender not in seen:
-                seen.add(sender)
-                self._upsert_contact_from_email(sender)
+    # ── Auto-contact helpers — provided by RetpostoContactMixin ─────────────
 
     # ── Keyring password helpers ────────────────────────────────────────────
 
@@ -391,8 +339,28 @@ class RetpostoService(CRUDService, MessageStore, RetpostoSignatureMixin):
     # ── Message search ─────────────────────────────────────────────────────────
 
     def get_message(self, uuid: str) -> dict[str, Any] | None:
-        """Get a message by UUID."""
-        return self.get(uuid)  # Uses inherited CRUDService.get
+        """Get a message by UUID (queries mesagxoj table directly)."""
+        return self.db.execute_one(
+            "SELECT * FROM mesagxoj WHERE uuid = ?", (uuid,)
+        )
+
+    def find_message_by_uuid_prefix(self, prefix: str) -> list[dict[str, Any]]:
+        """Find messages by UUID prefix (e.g. first 8 characters).
+
+        Args:
+            prefix: First N characters of a message UUID
+
+        Returns:
+            List of matching messages (empty if none)
+        """
+        if not prefix:
+            return []
+        return list(
+            self.db.execute(
+                "SELECT * FROM mesagxoj WHERE uuid LIKE ?",
+                (f"{prefix}%",),
+            )
+        )
 
     def search_messages(
         self, filters: dict[str, Any], limit: int = 50


### PR DESCRIPTION
## Bug Fix

**Issue #23:** `A retposto vidi 5a871019` rejected valid UUID displayed-prefix.

### Root Cause (two bugs)

1. **Primary bug:** No UUID prefix resolution for `retposto vidi` — exact match only
2. **Secondary bug (more severe):** `get_message()` via `CRUDService.get()` queried the service's configured table (`kontoj`) instead of `mesagxoj`. Even full message UUIDs failed.

### Fix

| File | Change |
|------|--------|
| `service/retposto_service.py` | Fix `get_message()` → direct `SELECT * FROM mesagxoj`; add `find_message_by_uuid_prefix()` |
| `cli/retposto.py` | Add `_resolve_message()` helper (exact → prefix → 0/many); update `retposto_vidi_mesago()` |
| `service/retposto_contact_mixin.py` | **NEW** — extract contact auto-save to mixin to keep `retposto_service.py` ≤ 500 lines |

Fixes #23