### PR TITLE
fix: use real IMAP UIDs for dedup instead of Message-ID header (fixes #31)

### DIFF
--- a/src/A_lien/data/migrate.py
+++ b/src/A_lien/data/migrate.py
@@ -33,6 +33,24 @@ def _rename_mesagxoj_to_mesagoj(conn: Any) -> None:
         conn.execute("ALTER TABLE mesagxoj RENAME TO mesagoj")
 
 
+def _imap_uid_migration(conn: Any) -> None:
+    """Migrate mesagoj: drop uid TEXT, add imap_uid INTEGER.
+
+    1. Drop old index referencing uid
+    2. Drop uid column (SQLite 3.35+)
+    3. Add imap_uid column
+    4. Add new partial unique index
+    """
+    conn.execute("DROP INDEX IF EXISTS idx_mesagoj_konto_uid")
+    conn.execute("ALTER TABLE mesagoj DROP COLUMN uid")
+    conn.execute("ALTER TABLE mesagoj ADD COLUMN imap_uid INTEGER")
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_mesagoj_imap_uid "
+        "ON mesagoj(konto_id, dosierujo_id, imap_uid) "
+        "WHERE imap_uid IS NOT NULL"
+    )
+
+
 # Migration registry: list of (version, description, steps)
 _MIGRATIONS: list[tuple[int, str, list[MigrationStep]]] = [
     # Version 1 is reserved for initial schema creation (done in storage.py)
@@ -43,6 +61,11 @@ _MIGRATIONS: list[tuple[int, str, list[MigrationStep]]] = [
             # Only rename if the old table exists (fresh installs use mesagoj)
             _rename_mesagxoj_to_mesagoj,
         ],
+    ),
+    (
+        3,
+        "Replace uid TEXT with imap_uid INTEGER for proper IMAP UID dedup",
+        [_imap_uid_migration],
     ),
 ]
 

--- a/src/A_lien/data/storage.py
+++ b/src/A_lien/data/storage.py
@@ -80,7 +80,7 @@ CREATE TABLE IF NOT EXISTS mesagoj (
     message_id     TEXT,
     in_reply_to    TEXT,
     references_hdr TEXT,
-    uid            TEXT,
+    imap_uid       INTEGER,
     de             TEXT,
     al             TEXT NOT NULL DEFAULT '[]',
     kc             TEXT NOT NULL DEFAULT '[]',
@@ -106,8 +106,10 @@ CREATE INDEX IF NOT EXISTS idx_mesagoj_konto ON mesagoj(konto_id);
 _IDX_MESAGXOJ_DOSIERUJO = """
 CREATE INDEX IF NOT EXISTS idx_mesagoj_dosierujo ON mesagoj(dosierujo_id);
 """
-_IDX_MESAGXOJ_KONTO_UID = """
-CREATE INDEX IF NOT EXISTS idx_mesagoj_konto_uid ON mesagoj(konto_id, uid);
+_IDX_MESAGXOJ_IMAP_UID = """
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mesagoj_imap_uid
+    ON mesagoj(konto_id, dosierujo_id, imap_uid)
+    WHERE imap_uid IS NOT NULL;
 """
 _IDX_MESAGXOJ_MESSAGE_ID = """
 CREATE INDEX IF NOT EXISTS idx_mesagoj_message_id ON mesagoj(konto_id, message_id);
@@ -247,8 +249,8 @@ _SCHEMA_STATEMENTS: list[str] = [
     _IDX_DOSIERUJOJ_KONTO,
     _IDX_MESAGXOJ_KONTO,
     _IDX_MESAGXOJ_DOSIERUJO,
-    _IDX_MESAGXOJ_KONTO_UID,
     _IDX_MESAGXOJ_MESSAGE_ID,
+    _IDX_MESAGXOJ_IMAP_UID,
     _IDX_MESAGXOJ_DATO,
     _IDX_ALDONAJXOJ_MESAGXO,
     _IDX_KONTAKTOJ_NOMO,

--- a/src/A_lien/imap/client.py
+++ b/src/A_lien/imap/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import imaplib
 import email as email_lib
+import re
 from email.utils import parsedate_to_datetime
 from datetime import datetime, timezone
 from typing import Any, Protocol
@@ -35,8 +36,8 @@ class SyncResult:
 class MessageStore(Protocol):
     """Interface for message persistence during IMAP sync."""
 
-    def get_known_uids(self, konto_id: str, dosierujo_id: str) -> set[str]:
-        """Return set of known IMAP UIDs for an account+folder combination."""
+    def get_known_uids(self, konto_id: str, dosierujo_id: str) -> set[int]:
+        """Return set of known IMAP UIDs (integers) for dedup."""
         ...
 
     def store_message(self, data: dict[str, Any]) -> str:
@@ -173,6 +174,9 @@ class IMAPClient:
     ) -> SyncResult:
         """Sync messages in a single folder, storing new ones.
 
+        Uses IMAP UID SEARCH/FETCH (RFC 3501) for stable dedup.
+        Fetches newest UIDs first, paginated in chunks of 100.
+
         Args:
             folder: IMAP folder name (e.g., 'INBOX')
             konto_id: Account UUID
@@ -190,49 +194,72 @@ class IMAPClient:
                 result.errors.append(f"Cannot select folder: {folder}")
                 return result
 
+            # Fetch all IMAP UIDs from server (stable per-folder identifiers)
+            typ, uid_data = self.conn.uid("search", None, "ALL")
+            if typ != "OK":
+                return result
+
+            if not uid_data[0]:
+                self.conn.close()
+                return result
+
+            all_uids = [int(x) for x in uid_data[0].split()]
+            result.total = len(all_uids)
+
+            # Filter out already-synced UIDs
             known_uids = db_store.get_known_uids(konto_id, dosierujo_id)
+            new_uids = [uid for uid in all_uids if uid not in known_uids]
 
-            typ, msg_ids = self.conn.search(None, "ALL")
-            if typ != "OK":
+            if not new_uids:
+                self.conn.close()
                 return result
 
-            ids = msg_ids[0].split() if msg_ids[0] else []
-            result.total = len(ids)
+            # Fetch newest UIDs first (UIDs are monotonically increasing)
+            new_uids.sort(reverse=True)
 
-            if not ids:
-                return result
+            # Paginate in chunks of 100 to avoid command-line overflow
+            chunk_size = 100
+            _IMAP_UID_RE = re.compile(rb"UID (\d+)")
 
-            typ, fetch_data = self.conn.fetch(
-                b",".join(ids), "(FLAGS BODY.PEEK[])",
-            )
-            if typ != "OK":
-                return result
+            for start in range(0, len(new_uids), chunk_size):
+                chunk = new_uids[start : start + chunk_size]
+                uid_list = b",".join(str(u).encode() for u in chunk)
 
-            for i in range(0, len(fetch_data), 2):
-                if not isinstance(fetch_data[i], tuple):
-                    continue
-                try:
-                    raw_data = fetch_data[i][1]
-                    msg = email_lib.message_from_bytes(raw_data)
-
-                    imap_uid = _decode_mime_header(msg.get("Message-ID", ""))
-                    if not imap_uid:
-                        imap_uid = str(uuid.uuid5(
-                            uuid.NAMESPACE_DNS, str(hash(raw_data)),
-                        ))
-
-                    if imap_uid in known_uids:
-                        result.total -= 1
-                        continue
-
-                    self._store_message(
-                        folder, msg, konto_id, dosierujo_id,
-                        imap_uid, db_store,
+                typ, fetch_data = self.conn.uid(
+                    "fetch", uid_list, "(FLAGS BODY.PEEK[])",
+                )
+                if typ != "OK":
+                    result.errors.append(
+                        f"FETCH error at UIDs {chunk[0]}..{chunk[-1]}"
                     )
-                    result.new += 1
+                    continue
 
-                except Exception as e:
-                    result.errors.append(f"Parse/store error: {e}")
+                for i in range(0, len(fetch_data), 2):
+                    if not isinstance(fetch_data[i], tuple):
+                        continue
+                    try:
+                        # Extract IMAP UID from FETCH response
+                        uid_match = _IMAP_UID_RE.search(fetch_data[i][0])
+                        if not uid_match:
+                            continue
+                        imap_uid = int(uid_match.group(1))
+
+                        if imap_uid in known_uids:
+                            continue
+
+                        raw_data = fetch_data[i][1]
+                        msg = email_lib.message_from_bytes(raw_data)
+
+                        self._store_message(
+                            folder, msg, konto_id, dosierujo_id,
+                            imap_uid, db_store,
+                        )
+                        result.new += 1
+
+                    except Exception as e:
+                        result.errors.append(
+                            f"Parse/store error at UID {imap_uid}: {e}"
+                        )
 
             self.conn.close()
         except Exception as e:
@@ -246,7 +273,7 @@ class IMAPClient:
         msg: Any,
         konto_id: str,
         dosierujo_id: str,
-        imap_uid: str,
+        imap_uid: int,
         db_store: MessageStore,
     ) -> str | None:
         """Parse a single email and store it via db_store."""
@@ -297,7 +324,7 @@ class IMAPClient:
             "message_id": message_id,
             "in_reply_to": in_reply_to,
             "references_hdr": references,
-            "uid": imap_uid,
+            "imap_uid": imap_uid,
             "de": from_header,
             "al": json.dumps(_parse_address_list(to_raw), ensure_ascii=False),
             "kc": json.dumps(_parse_address_list(cc_raw), ensure_ascii=False),

--- a/src/A_lien/service/retposto_service.py
+++ b/src/A_lien/service/retposto_service.py
@@ -49,7 +49,7 @@ class RetpostoService(CRUDService, MessageStore, RetpostoSignatureMixin, Retpost
 
     # ── MessageStore protocol implementation ──────────────────────────────────
 
-    def get_known_uids(self, konto_id: str, dosierujo_id: str) -> set[str]:
+    def get_known_uids(self, konto_id: str, dosierujo_id: str) -> set[int]:
         """Get set of already-synced IMAP UIDs for an account+folder.
 
         Args:
@@ -57,16 +57,19 @@ class RetpostoService(CRUDService, MessageStore, RetpostoSignatureMixin, Retpost
             dosierujo_id: Folder UUID
 
         Returns:
-            Set of UID strings (message_id / IMAP UID)
+            Set of integer IMAP UIDs
         """
         rows = self.db.execute(
-            "SELECT uid FROM mesagoj WHERE konto_id = ? AND dosierujo_id = ?",
+            "SELECT imap_uid FROM mesagoj WHERE konto_id = ? AND dosierujo_id = ? AND imap_uid IS NOT NULL",
             (konto_id, dosierujo_id),
         )
-        return {r["uid"] for r in rows if r.get("uid")}
+        return {r["imap_uid"] for r in rows}
 
     def store_message(self, data: dict[str, Any]) -> str:
-        """Insert a parsed message into mesagoj table.
+        """Insert a message into mesagoj table.
+
+        Dedup is handled upstream by sync_folder() (UID filtering)
+        and the partial unique index on (konto_id, dosierujo_id, imap_uid).
 
         Args:
             data: Parsed message dict
@@ -78,7 +81,7 @@ class RetpostoService(CRUDService, MessageStore, RetpostoSignatureMixin, Retpost
         self.db.execute(
             """INSERT OR IGNORE INTO mesagoj
                (uuid, konto_id, dosierujo_id, message_id, in_reply_to,
-                references_hdr, uid, de, al, kc, bkc,
+                references_hdr, imap_uid, de, al, kc, bkc,
                 subjekto, korpo, html_korpo,
                 prioritato, legita, stelo, spamo, forigita,
                 aldonajxoj, etikedoj, ricevita_je,
@@ -91,7 +94,7 @@ class RetpostoService(CRUDService, MessageStore, RetpostoSignatureMixin, Retpost
                 data.get("message_id", ""),
                 data.get("in_reply_to", ""),
                 data.get("references_hdr", ""),
-                data.get("uid", ""),
+                data.get("imap_uid"),
                 data.get("de", ""),
                 data.get("al", "[]"),
                 data.get("kc", "[]"),
@@ -316,7 +319,6 @@ class RetpostoService(CRUDService, MessageStore, RetpostoSignatureMixin, Retpost
             "message_id": f"sent-{uuid_mod.uuid4()}",
             "in_reply_to": "",
             "references_hdr": "",
-            "uid": f"sent-{uuid_mod.uuid4()}",
             "de": sender_email,
             "al": json.dumps(to, ensure_ascii=False),
             "kc": json.dumps(cc, ensure_ascii=False),

--- a/tests/test_imap_smtp.py
+++ b/tests/test_imap_smtp.py
@@ -83,7 +83,7 @@ class TestIMAPClient:
             mock_instance = MagicMock()
             mock.return_value = mock_instance
             mock_instance.select.return_value = ("OK", [b"0"])
-            mock_instance.search.return_value = ("OK", [b""])
+            mock_instance.uid.return_value = ("OK", [b""])
 
             # Build a fake store with empty known_uids
             fake_store = MagicMock()
@@ -101,9 +101,8 @@ class TestIMAPClient:
             mock_instance = MagicMock()
             mock.return_value = mock_instance
             mock_instance.select.return_value = ("OK", [b"1"])
-            mock_instance.search.return_value = ("OK", [b"1"])
 
-            # Build a fake email message
+            # Build a fake email message with a Message-ID
             msg_bytes = (
                 b"From: sender@test.com\r\n"
                 b"To: recipient@test.com\r\n"
@@ -113,10 +112,13 @@ class TestIMAPClient:
                 b"\r\n"
                 b"Hello, this is a test."
             )
-            mock_instance.fetch.return_value = (
-                "OK",
-                [(b"1 (FLAGS (\\Seen))", msg_bytes)],
-            )
+            # uid() is called twice: uid('search', ...) then uid('fetch', ...)
+            mock_instance.uid.side_effect = [
+                ("OK", [b"100"]),              # uid('search', None, "ALL")
+                ("OK", [                         # uid('fetch', ...)
+                    (b"1 (UID 100 FLAGS (\\Seen) BODY[] {42}", msg_bytes),
+                ]),
+            ]
 
             fake_store = MagicMock()
             fake_store.get_known_uids.return_value = set()
@@ -134,7 +136,6 @@ class TestIMAPClient:
             mock_instance = MagicMock()
             mock.return_value = mock_instance
             mock_instance.select.return_value = ("OK", [b"1"])
-            mock_instance.search.return_value = ("OK", [b"1"])
 
             msg_bytes = (
                 b"From: John Doe <john@test.com>\r\n"
@@ -147,10 +148,12 @@ class TestIMAPClient:
                 b"\r\n"
                 b"Body content here."
             )
-            mock_instance.fetch.return_value = (
-                "OK",
-                [(b"1 (FLAGS (\\Seen))", msg_bytes)],
-            )
+            mock_instance.uid.side_effect = [
+                ("OK", [b"200"]),              # uid('search', ...)
+                ("OK", [                         # uid('fetch', ...)
+                    (b"1 (UID 200 FLAGS (\\Seen) BODY[] {48}", msg_bytes),
+                ]),
+            ]
 
             fake_store = MagicMock()
             fake_store.get_known_uids.return_value = set()


### PR DESCRIPTION
## Root Cause
`sync_folder()` used the **Message-ID email header** as the dedup identifier. Some emails lack a Message-ID, and the `hash(raw_data)` fallback is **randomized per Python process** (PYTHONHASHSEED) — causing infinite re-download of those messages.

## Changes
### Schema (migration v3)
- **`uid TEXT` removed** — redundant with `message_id` column
- **`imap_uid INTEGER` added** — stores real IMAP UID (RFC 3501)
- Partial unique index on `(konto_id, dosierujo_id, imap_uid) WHERE imap_uid IS NOT NULL`

### IMAP sync (`imap/client.py`)
- `conn.uid("search", None, "ALL")` instead of `conn.search(None, "ALL")` — returns stable UIDs, not volatile sequence numbers
- `conn.uid("fetch", ...)` with UID extracted from response via regex
- **Newest-first ordering** (UIDs sorted descending)
- **Chunked pagination** (100 UIDs per fetch) — prevents command-line overflow

### Service layer (`retposto_service.py`)
- `get_known_uids()` returns `set[int]` queried from `imap_uid` column
- `store_message()` simplified — dedup handled by upstream UID filtering + partial unique index
- Sent messages no longer write synthetic `uid` values (unnecessary)

### Tests
- Mocks use `conn.uid()` with `side_effect` (search then fetch)
- Fetch responses include `UID n` in flags string for regex extraction

## Migration Impact
1. All existing `mesagoj` rows lose their `uid` value (Message-ID string)
2. First sync after migration: all messages appear "new" → re-downloaded
3. Second sync: dedup works correctly using `imap_uid` → instant
