### PR TITLE
fix: get_db() must run migrate() to apply schema changes (fixes #31)

### DIFF
--- a/src/A_lien/data/migrate.py
+++ b/src/A_lien/data/migrate.py
@@ -36,11 +36,21 @@ def _rename_mesagxoj_to_mesagoj(conn: Any) -> None:
 def _imap_uid_migration(conn: Any) -> None:
     """Migrate mesagoj: drop uid TEXT, add imap_uid INTEGER.
 
+    Only runs if uid column still exists (legacy databases).
+    Fresh installs using the current schema already have imap_uid.
+
     1. Drop old index referencing uid
     2. Drop uid column (SQLite 3.35+)
     3. Add imap_uid column
     4. Add new partial unique index
     """
+    # Guard: skip if uid column doesn't exist (fresh install or already migrated)
+    row = conn.execute(
+        "SELECT COUNT(*) as cnt FROM pragma_table_info('mesagoj') WHERE name='uid'"
+    ).fetchone()
+    if not row or row["cnt"] == 0:
+        return
+
     conn.execute("DROP INDEX IF EXISTS idx_mesagoj_konto_uid")
     conn.execute("ALTER TABLE mesagoj DROP COLUMN uid")
     conn.execute("ALTER TABLE mesagoj ADD COLUMN imap_uid INTEGER")

--- a/src/A_lien/data/storage.py
+++ b/src/A_lien/data/storage.py
@@ -294,19 +294,24 @@ def ensure_dirs() -> None:
 
 
 def get_db(path: str | None = None) -> SQLiteDB:
-    """Get database connection with all tables created.
+    """Get database connection with all tables created and migrations applied.
 
     Args:
         path: Optional override path (default: data_dir() / lien.db)
 
     Returns:
-        SQLiteDB instance with schema applied
+        SQLiteDB instance with schema + migrations applied
     """
     ensure_dirs()
     db = SQLiteDB(path or _path())
 
     for stmt in _SCHEMA_STATEMENTS:
         db.execute(stmt)
+
+    # Apply any pending schema migrations (e.g. imap_uid column)
+    from A_lien.data.migrate import migrate as _migrate
+
+    _migrate(db)
 
     return db
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -125,7 +125,7 @@ class TestGetDB:
         indexes = all_indexes(db)
         assert "idx_dosierujoj_konto" in indexes
         assert "idx_mesagoj_konto" in indexes
-        assert "idx_mesagoj_konto_uid" in indexes
+        assert "idx_mesagoj_imap_uid" in indexes
         assert "idx_mesagoj_dato" in indexes
         assert "idx_aldonajxoj_mesagxo" in indexes
         assert "idx_kontaktoj_nomo" in indexes
@@ -187,23 +187,42 @@ class TestFTSConfig:
 class TestMigrate:
     """Tests for migration system."""
 
-    def test_schema_version_starts_at_0(self, db):
-        """Fresh database starts at version 0."""
+    def _fresh_db_no_migrate(self, tmp_path) -> Any:
+        """Create a SQLiteDB with schema DDL but no migrations applied.
+
+        This simulates an old database that hasn't been migrated.
+        """
+        from A.data.base import SQLiteDB
+        from A_lien.data.storage import _SCHEMA_STATEMENTS
+
+        db_path = str(tmp_path / "test_pre_migrate.db")
+        db = SQLiteDB(db_path)
+        for stmt in _SCHEMA_STATEMENTS:
+            db.execute(stmt)
+        return db
+
+    def test_schema_version_starts_at_0(self, tmp_path):
+        """Fresh database without migrations starts at version 0."""
+        db = self._fresh_db_no_migrate(tmp_path)
         version = get_schema_version(db)
         assert version == 0
 
-    def test_migrate_noop_with_no_pending(self, db):
-        """Migrate on fresh DB applies idempotent migrations only.
-
-        Migration 2 (mesagxoj -> mesagoj rename) is a no-op on fresh
-        installs because the old table never existed, but it still
-        gets recorded to prevent re-running on future upgrades.
-        """
+    def test_migrate_applies_pending(self, tmp_path):
+        """Migrate on an un-migrated DB applies all pending migrations."""
+        db = self._fresh_db_no_migrate(tmp_path)
         applied = migrate(db)
-        assert len(applied) == 1
-        assert "mesagxoj" in applied[0]
+        # Both migration 2 (mesagxoj rename) and 3 (imap_uid) apply
+        assert len(applied) >= 2
         version = get_schema_version(db)
-        assert version == 2
+        assert version >= 3
+
+    def test_migrate_idempotent(self, tmp_path):
+        """Calling migrate twice is a no-op the second time."""
+        db = self._fresh_db_no_migrate(tmp_path)
+        applied1 = migrate(db)
+        applied2 = migrate(db)
+        assert len(applied1) >= 2
+        assert applied2 == []
 
 
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Root Cause
`get_db()` ran `CREATE TABLE IF NOT EXISTS` DDL but never called `migrate()`. So versioned schema changes (`ALTER TABLE DROP/ADD COLUMN`) were never applied to existing databases. This caused `OperationalError: no such column: imap_uid` on first use after the IMAP UID dedup upgrade.

## Changes
- **`get_db()` now calls `migrate()`** after creating the base schema
- **Migration v3 guards `DROP COLUMN uid`** — checks via `pragma_table_info` first, since fresh installs already use the new schema
- **Tests updated** — `_fresh_db_no_migrate()` helper tests migrations on a pre-migration DB independently of `get_db()` auto-migrate

## Systematic review
Checked all 7 A-modules. Only A-lien had this bug (has `migrate.py` but never called it in `get_db()`). A-vorto and A-encik already call migrate() correctly. Others (organizi, medio, sekurkopio, agento) don't have versioned migrations yet.
