### PR TITLE
fix: DDL-before-migration ordering bug — 'no such column: imap_uid' (fixes #31)

### DIFF
--- a/src/A_lien/data/migrate.py
+++ b/src/A_lien/data/migrate.py
@@ -30,30 +30,41 @@ def _rename_mesagxoj_to_mesagoj(conn: Any) -> None:
         "SELECT name FROM sqlite_master WHERE type='table' AND name='mesagxoj'"
     ).fetchone()
     if row:
+        conn.execute("DROP TABLE IF EXISTS mesagoj")
         conn.execute("ALTER TABLE mesagxoj RENAME TO mesagoj")
 
 
 def _imap_uid_migration(conn: Any) -> None:
-    """Migrate mesagoj: drop uid TEXT, add imap_uid INTEGER.
+    """Ensure mesagoj has imap_uid INTEGER column and its unique index.
 
-    Only runs if uid column still exists (legacy databases).
-    Fresh installs using the current schema already have imap_uid.
-
-    1. Drop old index referencing uid
-    2. Drop uid column (SQLite 3.35+)
-    3. Add imap_uid column
-    4. Add new partial unique index
+    Three scenarios:
+    1. Legacy DB:  uid TEXT exists, imap_uid missing
+       → drop old index, drop uid, add imap_uid, create new index
+    2. Fresh DB:   imap_uid exists (from DDL), uid missing
+       → create index only (column already exists)
+    3. Re-run:     both exist, index exists
+       → all IF NOT EXISTS → no-ops
     """
-    # Guard: skip if uid column doesn't exist (fresh install or already migrated)
-    row = conn.execute(
+    has_uid = conn.execute(
         "SELECT COUNT(*) as cnt FROM pragma_table_info('mesagoj') WHERE name='uid'"
     ).fetchone()
-    if not row or row["cnt"] == 0:
-        return
+    has_imap_uid = conn.execute(
+        "SELECT COUNT(*) as cnt FROM pragma_table_info('mesagoj') WHERE name='imap_uid'"
+    ).fetchone()
 
-    conn.execute("DROP INDEX IF EXISTS idx_mesagoj_konto_uid")
-    conn.execute("ALTER TABLE mesagoj DROP COLUMN uid")
-    conn.execute("ALTER TABLE mesagoj ADD COLUMN imap_uid INTEGER")
+    # Legacy cleanup: drop old uid column and its index
+    if has_uid and has_uid["cnt"] > 0:
+        # Index may be named with old diacritic name (idx_mesagxoj_*)
+        # if it was created before migration v2 renamed the table.
+        conn.execute("DROP INDEX IF EXISTS idx_mesagoj_konto_uid")
+        conn.execute("DROP INDEX IF EXISTS idx_mesagxoj_konto_uid")
+        conn.execute("ALTER TABLE mesagoj DROP COLUMN uid")
+
+    # Add imap_uid if column is missing (fresh DBs already have it)
+    if has_imap_uid and has_imap_uid["cnt"] == 0:
+        conn.execute("ALTER TABLE mesagoj ADD COLUMN imap_uid INTEGER")
+
+    # Always ensure the index exists (idempotent for all scenarios)
     conn.execute(
         "CREATE UNIQUE INDEX IF NOT EXISTS idx_mesagoj_imap_uid "
         "ON mesagoj(konto_id, dosierujo_id, imap_uid) "
@@ -86,6 +97,7 @@ def _rename_mesagxoj_to_mesagoj(conn: Any) -> None:
         "SELECT name FROM sqlite_master WHERE type='table' AND name='mesagxoj'"
     ).fetchone()
     if row:
+        conn.execute("DROP TABLE IF EXISTS mesagoj")
         conn.execute("ALTER TABLE mesagxoj RENAME TO mesagoj")
 
 

--- a/src/A_lien/data/storage.py
+++ b/src/A_lien/data/storage.py
@@ -250,7 +250,8 @@ _SCHEMA_STATEMENTS: list[str] = [
     _IDX_MESAGXOJ_KONTO,
     _IDX_MESAGXOJ_DOSIERUJO,
     _IDX_MESAGXOJ_MESSAGE_ID,
-    _IDX_MESAGXOJ_IMAP_UID,
+    # _IDX_MESAGXOJ_IMAP_UID moved to migration v3
+    # (column may not exist yet on legacy DBs from DDL alone)
     _IDX_MESAGXOJ_DATO,
     _IDX_ALDONAJXOJ_MESAGXO,
     _IDX_KONTAKTOJ_NOMO,

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -224,6 +224,84 @@ class TestMigrate:
         assert len(applied1) >= 2
         assert applied2 == []
 
+    def test_legacy_db_upgrade(self, tmp_path):
+        """Legacy DB with uid TEXT column upgrades to imap_uid without crash.
+
+        Simulates the exact bug scenario: a DB from before the IMAP UID
+        migration (uid TEXT exists, imap_uid missing, old index exists).
+        verifies get_db() succeeds and the new index is created.
+        """
+        from A.data.base import SQLiteDB
+
+        # Build a legacy mesagoj table (old schema with uid TEXT)
+        db_path = str(tmp_path / "test_legacy.db")
+        db = SQLiteDB(db_path)
+        db.execute("""
+            CREATE TABLE IF NOT EXISTS mesagoj (
+                uuid           TEXT PRIMARY KEY,
+                konto_id       TEXT NOT NULL,
+                dosierujo_id   TEXT,
+                message_id     TEXT,
+                in_reply_to    TEXT,
+                references_hdr TEXT,
+                uid            TEXT,
+                de             TEXT,
+                al             TEXT NOT NULL DEFAULT '[]',
+                kc             TEXT NOT NULL DEFAULT '[]',
+                bkc            TEXT NOT NULL DEFAULT '[]',
+                subjekto       TEXT,
+                korpo          TEXT,
+                html_korpo     TEXT,
+                prioritato     INTEGER DEFAULT 5,
+                legita         INTEGER NOT NULL DEFAULT 0,
+                stelo          INTEGER NOT NULL DEFAULT 0,
+                spamo          INTEGER NOT NULL DEFAULT 0,
+                forigita       INTEGER NOT NULL DEFAULT 0,
+                aldonajxoj     TEXT NOT NULL DEFAULT '[]',
+                etikedoj       TEXT NOT NULL DEFAULT '[]',
+                ricevita_je    TEXT,
+                kreita_je      TEXT NOT NULL,
+                modifita_je    TEXT NOT NULL
+            )
+        """)
+        db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_mesagoj_konto_uid "
+            "ON mesagoj(konto_id, uid)"
+        )
+        # Insert a sample row to confirm schema is valid
+        db.execute(
+            "INSERT INTO mesagoj (uuid, konto_id, uid, kreita_je, modifita_je) "
+            "VALUES (?, ?, ?, datetime('now'), datetime('now'))",
+            ("test-uuid", "test-konto", "<abc@test.com>"),
+        )
+
+        # Now run get_db() — this should NOT crash (the bug)
+        from A_lien.data.storage import get_db
+
+        db2 = get_db(str(tmp_path / "test_legacy.db"))
+
+        # Verify the new column exists
+        cols = {
+            r["name"]
+            for r in db2.execute("PRAGMA table_info(mesagoj)")
+        }
+        assert "imap_uid" in cols, "imap_uid column should exist after migration"
+        assert "uid" not in cols, "uid column should have been dropped"
+
+        # Verify the new index exists
+        indexes = {
+            r["name"]
+            for r in db2.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%'"
+            )
+        }
+        assert "idx_mesagoj_imap_uid" in indexes
+        assert "idx_mesagoj_konto_uid" not in indexes
+
+        # Existing data is preserved
+        row = db2.execute_one("SELECT uuid FROM mesagoj WHERE uuid='test-uuid'")
+        assert row is not None
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Keyring tests


### PR DESCRIPTION
## Root Cause
`get_db()` ran DDL (including index on `imap_uid`) **before** migration v3 could add the `imap_uid` column. `CREATE TABLE IF NOT EXISTS` is a no-op on existing tables — it doesn't add new columns. So the index creation failed with `OperationalError: no such column: imap_uid`.

## Fix
| File | Change |
|------|--------|
| `storage.py` | Remove `_IDX_MESAGXOJ_IMAP_UID` from `_SCHEMA_STATEMENTS` — cannot create index before column exists |
| `migrate.py` (v3) | Always create index; also checks for old `idx_mesagxoj_konto_uid` name (legacy autish) |
| `migrate.py` (v2) | `DROP TABLE IF EXISTS mesagoj` before `RENAME` — DDL created empty target first |
| `tests/test_storage.py` | New `test_legacy_db_upgrade` — builds old schema, runs `get_db()`, verifies column + index |

## Systematic review
Same bug pattern (`get_db()` runs DDL before `migrate()`) exists in **A-vorto** and **A-encik** only — both already call `migrate()` correctly with no issues. No other modules have versioned schema migrations.
