### PR TITLE
fix: IMAP sync robustness — paginated SEARCH, robust parsing, v4 cleanup (fixes #31)

### DIFF
--- a/src/A_lien/data/migrate.py
+++ b/src/A_lien/data/migrate.py
@@ -88,6 +88,11 @@ _MIGRATIONS: list[tuple[int, str, list[MigrationStep]]] = [
         "Replace uid TEXT with imap_uid INTEGER for proper IMAP UID dedup",
         [_imap_uid_migration],
     ),
+    (
+        4,
+        "Delete stale rows with imap_uid=NULL to prevent first-sync duplicates",
+        ["DELETE FROM mesagoj WHERE imap_uid IS NULL AND dosierujo_id != ''"],
+    ),
 ]
 
 

--- a/src/A_lien/imap/client.py
+++ b/src/A_lien/imap/client.py
@@ -194,16 +194,34 @@ class IMAPClient:
                 result.errors.append(f"Cannot select folder: {folder}")
                 return result
 
-            # Fetch all IMAP UIDs from server (stable per-folder identifiers)
-            typ, uid_data = self.conn.uid("search", None, "ALL")
-            if typ != "OK":
-                return result
+            # Fetch all IMAP UIDs from server (stable per-folder identifiers).
+            # Some servers cap SEARCH at ~5000 results — paginate if needed.
+            all_uids: list[int] = []
+            search_uid_from = None  # None = "ALL"
+            while True:
+                if search_uid_from is not None:
+                    typ, uid_data = self.conn.uid(
+                        "search", None, f"UID {search_uid_from}:*",
+                    )
+                else:
+                    typ, uid_data = self.conn.uid("search", None, "ALL")
 
-            if not uid_data[0]:
-                self.conn.close()
-                return result
+                if typ != "OK":
+                    return result
+                if not uid_data or not uid_data[0]:
+                    break
 
-            all_uids = [int(x) for x in uid_data[0].split()]
+                chunk = [int(x) for x in uid_data[0].split()]
+                if not chunk:
+                    break
+                all_uids.extend(chunk)
+
+                # If result count is suspiciously round, try fetching more
+                if len(chunk) in (5000, 10000, 20000):
+                    search_uid_from = chunk[-1] + 1
+                else:
+                    break
+
             result.total = len(all_uids)
 
             # Filter out already-synced UIDs
@@ -234,20 +252,25 @@ class IMAPClient:
                     )
                     continue
 
-                for i in range(0, len(fetch_data), 2):
-                    if not isinstance(fetch_data[i], tuple):
+                for item in fetch_data:
+                    if not isinstance(item, tuple):
                         continue
+                    raw_flags = item[0] if item[0] else b""
+                    raw_data = item[1]
+                    imap_uid = -1  # placeholder for error messages
                     try:
                         # Extract IMAP UID from FETCH response
-                        uid_match = _IMAP_UID_RE.search(fetch_data[i][0])
+                        uid_match = _IMAP_UID_RE.search(raw_flags)
                         if not uid_match:
+                            result.errors.append(
+                                f"UID regex failed on: {raw_flags[:200]!r}"
+                            )
                             continue
                         imap_uid = int(uid_match.group(1))
 
                         if imap_uid in known_uids:
                             continue
 
-                        raw_data = fetch_data[i][1]
                         msg = email_lib.message_from_bytes(raw_data)
 
                         self._store_message(


### PR DESCRIPTION
## Fixes (4 issues)

### 1. Migration v4: Clean stale rows
`DELETE FROM mesagoj WHERE imap_uid IS NULL AND dosierujo_id != ''` — removes pre-migration rows that have no IMAP UID, preventing re-import duplicates on first post-migration sync.

### 2. Robust fetch parsing
Replaced `for i in range(0, len(fetch_data), 2)` with `isinstance(item, tuple)` filter. The old code assumed every even index is a tuple — a single non-tuple FLAGS-only response would misalign all subsequent messages, causing phantom "new" matches and duplicates.

### 3. Log regex failures
`result.errors.append()` now logs when the UID regex `rb"UID (\d+)"` doesn't match a fetch response, including a snippet of the raw flags for debugging.

### 4. Paginated UID SEARCH
If `UID SEARCH ALL` returns a round number (5000/10000/20000 — common server caps), the code now fetches more via `UID SEARCH UID N+1:*` repeatedly until empty. This fixes "newest emails missing" on servers like Exchange/Yahoo that limit SEARCH results.

## Tests
119/119 passed.
