### PR TITLE
feat: typed connection error messages with i18n + remediation hints

### DIFF
--- a/src/A_lien/cli/retposto.py
+++ b/src/A_lien/cli/retposto.py
@@ -143,6 +143,9 @@ def retposto_preni(
         try:
             result = svc.sync_account(acct["uuid"])
             _report_sync(result, account_label=email)
+        except ConnectionError as e:
+            error(str(e))
+            raise typer.Exit(1)
         except Exception as e:
             error(f"[{email}] {e}")
             raise typer.Exit(1)
@@ -246,6 +249,9 @@ def retposto_sendi(
             f"Message sent to {to}",
             f"Message envoyé à {to}",
         ))
+    except ConnectionError as e:
+        error(str(e))
+        raise typer.Exit(1)
     except Exception as e:
         error(tr_multi(
             f"Sendado malsukcesis: {e}",
@@ -341,6 +347,9 @@ def retposto_dosierujoj(
         folders = client.list_folders()
         for f in folders:
             info(f"  {f['name']}")
+    except ConnectionError as e:
+        error(str(e))
+        raise typer.Exit(1)
     except Exception as e:
         error(str(e))
         raise typer.Exit(1)
@@ -377,6 +386,9 @@ def retposto_mesagoj(
             f"Found {result.total} messages (fetched: {result.new} new)",
             f"Trouvé {result.total} messages (récupérés: {result.new} nouveaux)",
         ))
+    except ConnectionError as e:
+        error(str(e))
+        raise typer.Exit(1)
     except Exception as e:
         error(str(e))
         raise typer.Exit(1)

--- a/src/A_lien/imap/client.py
+++ b/src/A_lien/imap/client.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 import imaplib
 import email as email_lib
 import re
+import socket
+import ssl
 from email.utils import parsedate_to_datetime
 from datetime import datetime, timezone
 from typing import Any, Protocol
 import uuid
 import json
 
+from A import tr_multi
+from A.core.network import format_connection_error
 from A_lien.imap.helpers import (
     _decode_mime_header,
     _parse_address_list,
@@ -71,7 +75,6 @@ class IMAPClient:
                 self._conn = imaplib.IMAP4(self.host, self.port)
             self._conn.login(username, password)
         except imaplib.IMAP4.error as e:
-            from A import tr_multi
             raise ConnectionError(
                 tr_multi(
                     f"IMAP-aŭtentigo malsukcesis por {username}@{self.host}:{self.port} — {e}",
@@ -79,8 +82,12 @@ class IMAPClient:
                     f"Échec d'authentification IMAP pour {username}@{self.host}:{self.port} — {e}",
                 )
             ) from e
+        except (socket.gaierror, ConnectionRefusedError,
+                TimeoutError, socket.timeout, ssl.SSLError, OSError) as e:
+            raise ConnectionError(
+                format_connection_error(e, self.host, self.port, "IMAP")
+            ) from e
         except Exception as e:
-            from A import tr_multi
             raise ConnectionError(
                 tr_multi(
                     f"IMAP-konekto malsukcesis al {username}@{self.host}:{self.port} — {e}",

--- a/src/A_lien/sieve.py
+++ b/src/A_lien/sieve.py
@@ -7,8 +7,12 @@ Provides:
 
 from __future__ import annotations
 
+import socket
+import ssl
 from typing import Any
 
+from A import tr_multi
+from A.core.network import format_connection_error
 from A_lien.service import get_retposto_service
 
 
@@ -66,8 +70,19 @@ class SieveManager:
             from managesieve import MANAGESIEVE as SieveClient
             self._client = SieveClient(self.host, self.port, use_tls=self.use_tls)
             self._client.login(username, password)
+        except (socket.gaierror, ConnectionRefusedError,
+                TimeoutError, socket.timeout, ssl.SSLError, OSError) as e:
+            raise ConnectionError(
+                format_connection_error(e, self.host, self.port, "Sieve")
+            ) from e
         except Exception as e:
-            raise ConnectionError(f"Sieve connection failed: {e}") from e
+            raise ConnectionError(
+                tr_multi(
+                    f"Sieve-konekto malsukcesis al {username}@{self.host}:{self.port} — {e}",
+                    f"Sieve connection failed to {username}@{self.host}:{self.port} — {e}",
+                    f"Échec de connexion Sieve vers {username}@{self.host}:{self.port} — {e}",
+                )
+            ) from e
 
     @property
     def client(self) -> Any:

--- a/src/A_lien/smtp.py
+++ b/src/A_lien/smtp.py
@@ -7,12 +7,17 @@ using stdlib smtplib and email.mime.
 from __future__ import annotations
 
 import smtplib
+import socket
+import ssl
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from email.mime.base import MIMEBase
 from email import encoders
 from pathlib import Path
 from typing import Any
+
+from A import tr_multi
+from A.core.network import format_connection_error
 
 
 class SMTPClient:
@@ -43,8 +48,27 @@ class SMTPClient:
                 self._conn.ehlo()
 
             self._conn.login(username, password)
+        except smtplib.SMTPAuthenticationError as e:
+            raise ConnectionError(
+                tr_multi(
+                    f"SMTP-aŭtentigo malsukcesis por {username}@{self.host}:{self.port} — {e}",
+                    f"SMTP authentication failed for {username}@{self.host}:{self.port} — {e}",
+                    f"Échec d'authentification SMTP pour {username}@{self.host}:{self.port} — {e}",
+                )
+            ) from e
+        except (socket.gaierror, ConnectionRefusedError,
+                TimeoutError, socket.timeout, ssl.SSLError, OSError) as e:
+            raise ConnectionError(
+                format_connection_error(e, self.host, self.port, "SMTP")
+            ) from e
         except Exception as e:
-            raise ConnectionError(f"SMTP connection failed: {e}") from e
+            raise ConnectionError(
+                tr_multi(
+                    f"SMTP-konekto malsukcesis al {username}@{self.host}:{self.port} — {e}",
+                    f"SMTP connection failed to {username}@{self.host}:{self.port} — {e}",
+                    f"Échec de connexion SMTP vers {username}@{self.host}:{self.port} — {e}",
+                )
+            ) from e
 
     @property
     def conn(self) -> smtplib.SMTP:
@@ -121,7 +145,13 @@ class SMTPClient:
         try:
             self.conn.sendmail(from_addr, all_recipients, msg.as_string())
         except Exception as e:
-            raise ConnectionError(f"SMTP send failed: {e}") from e
+            raise ConnectionError(
+                tr_multi(
+                    f"SMTP-sendo malsukcesis: {e}",
+                    f"SMTP send failed: {e}",
+                    f"Échec d'envoi SMTP: {e}",
+                )
+            ) from e
 
     @staticmethod
     def _attach_file(msg: MIMEMultipart, path: str | Path) -> None:


### PR DESCRIPTION
Uses `A.core.network.format_connection_error()` across IMAP, SMTP, and Sieve clients to provide user-friendly error messages.

Changes:
- IMAP: socket-level errors now show DNS/refused/timeout/SSL hints
- SMTP: added tr_multi i18n + typed errors + host/port in messages
- Sieve: added tr_multi i18n + typed errors
- CLI: ConnectionError shown cleanly, separate from generic exceptions