### PR TITLE
fix: use error() not warning() for sync error display

### DIFF
--- a/src/A_lien/cli/retposto.py
+++ b/src/A_lien/cli/retposto.py
@@ -103,7 +103,7 @@ def _report_sync(result: Any, account_label: str = "") -> None:
         ))
     info(f"{prefix}{', '.join(parts)}")
     for err in result.errors[:3]:
-        warning(f"  {prefix}{err}")
+        error(f"  {prefix}{err}")
 
 
 # ── Mail operations ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Sync errors (e.g. connection failures) should use error() output (red/stderr) instead of warning() (yellow).