### PR TITLE
feat: add --dosierujo folder filter to serci and preni

### DIFF
--- a/src/A_lien/cli/retposto.py
+++ b/src/A_lien/cli/retposto.py
@@ -120,6 +120,14 @@ def retposto_preni(
             "UUID ou préfixe de compte spécifique",
         ),
     ),
+    folder: str = typer.Option(
+        "", "--dosierujo", "-f",
+        help=tr_multi(
+            "Dosieruja nomo (ekz. INBOX; postulas --konto)",
+            "Folder name (e.g. INBOX; requires --konto)",
+            "Nom du dossier (p. ex. INBOX; nécessite --konto)",
+        ),
+    ),
     force: bool = typer.Option(
         False, "--deviga", "-d",
         help=tr_multi(
@@ -141,6 +149,7 @@ def retposto_preni(
 
     By default syncs all accounts with passwords.
     Use --konto to sync a single account (by UUID or prefix).
+    Use --dosierujo with --konto to sync only a specific folder.
     Use --deviga to re-download all messages (not just new ones).
     """
     # Enable IMAP debug logging globally
@@ -150,6 +159,15 @@ def retposto_preni(
 
     svc = get_retposto_service()
 
+    # --dosierujo without --konto is invalid
+    if folder and not account:
+        error(tr_multi(
+            "--dosierujo postulas --konto",
+            "--dosierujo requires --konto",
+            "--dosierujo nécessite --konto",
+        ))
+        raise typer.Exit(1)
+
     if account:
         # Single account — resolve UUID prefix
         acct = svc.get_account(account)
@@ -158,13 +176,16 @@ def retposto_preni(
 
             acct = _resolve_account(svc, account)
         email = acct.get("retposto", account[:8])
+        folder_label = f" [{folder}]" if folder else ""
         info(tr_multi(
-            f"Prenas mesaĝojn el {email}...",
-            f"Fetching messages from {email}...",
-            f"Récupération depuis {email}...",
+            f"Prenas mesaĝojn el {email}{folder_label}...",
+            f"Fetching messages from {email}{folder_label}...",
+            f"Récupération depuis {email}{folder_label}...",
         ))
         try:
-            result = svc.sync_account(acct["uuid"], force=force)
+            folders_arg = [folder] if folder else None
+            result = svc.sync_account(acct["uuid"], force=force,
+                                      folders=folders_arg)
             _report_sync(result, account_label=email)
         except ConnectionError as e:
             error(str(e))

--- a/src/A_lien/cli/retposto_search.py
+++ b/src/A_lien/cli/retposto_search.py
@@ -14,6 +14,28 @@ from A import error, info, tr_multi
 from A_lien.service import get_retposto_service
 
 
+def _format_results(results: list[dict]) -> list[str]:
+    """Format search results as a list of text lines, including folder name."""
+    lines: list[str] = [
+        tr_multi(
+            f"Trovitaj {len(results)} mesaĝo(j):",
+            f"Found {len(results)} message(s):",
+            f"{len(results)} message(s) trouvé(s):",
+        ),
+    ]
+    for m in results:
+        read_indicator = (
+            tr_multi("legita", "read", "lu")
+            if m.get("legita")
+            else tr_multi("nelegita", "unread", "non lu")
+        )
+        folder = m.get("dosierujo_nomo", "") or ""
+        preview = (m.get("subjekto", "") or "(sen temo)")[:50]
+        folder_part = f" [{folder}]" if folder else ""
+        lines.append(f"  {m['uuid'][:8]}  {read_indicator}{folder_part}: {preview}")
+    return lines
+
+
 def retposto_serci(
     query: str = typer.Argument(
         "", help=tr_multi("Serĉa teksto", "Search text", "Texte de recherche")
@@ -74,6 +96,14 @@ def retposto_serci(
         "", "--konto", "-a",
         help=tr_multi("Konto UUID", "Account UUID", "UUID compte"),
     ),
+    folder: str = typer.Option(
+        "", "--dosierujo", "-d",
+        help=tr_multi(
+            "Dosieruja nomo (ekz. INBOX, Sent, Junk)",
+            "Folder name (e.g. INBOX, Sent, Junk)",
+            "Nom du dossier (p. ex. INBOX, Sent, Junk)",
+        ),
+    ),
 ) -> None:
     """Search emails with filters."""
     svc = get_retposto_service()
@@ -105,6 +135,8 @@ def retposto_serci(
         filters["priority"] = priority
     if account:
         filters["account"] = account
+    if folder:
+        filters["folder"] = folder
 
     results = svc.search_messages(filters, limit=limit)
 
@@ -116,20 +148,9 @@ def retposto_serci(
         ))
         return
 
-    info(tr_multi(
-        f"Trovitaj {len(results)} mesaĝo(j):",
-        f"Found {len(results)} message(s):",
-        f"{len(results)} message(s) trouvé(s):",
-    ))
-
-    for m in results:
-        read_indicator = (
-            tr_multi("legita", "read", "lu")
-            if m.get("legita")
-            else tr_multi("nelegita", "unread", "non lu")
-        )
-        preview = (m.get("subjekto", "") or "(sen temo)")[:50]
-        info(f"  {m['uuid'][:8]}  {read_indicator}: {preview}")
+    lines = _format_results(results)
+    for line in lines:
+        info(line)
 
 
-__all__ = ["retposto_serci"]
+__all__ = ["retposto_serci", "_format_results"]

--- a/src/A_lien/cli/retposto_vidi.py
+++ b/src/A_lien/cli/retposto_vidi.py
@@ -17,6 +17,24 @@ from A_lien.cli.retposto_message_ops import _resolve_message
 from A_lien.service import get_retposto_service
 
 
+def _lookup_folder_name(svc: Any, dosierujo_id: str) -> str:
+    """Look up folder display name by its UUID.
+
+    Args:
+        svc: RetpostoService instance.
+        dosierujo_id: Folder UUID from the message.
+
+    Returns:
+        Folder name or empty string if not found.
+    """
+    if not dosierujo_id:
+        return ""
+    row = svc.db.execute_one(
+        "SELECT nomo FROM dosierujoj WHERE uuid = ?", (dosierujo_id,)
+    )
+    return row["nomo"] if row else ""
+
+
 def _format_size(size: int) -> str:
     """Format byte count to human-readable string."""
     if size > 1024 * 1024:
@@ -64,7 +82,7 @@ def _build_attachments_html(attachments: list[dict[str, Any]]) -> str:
 def _build_metadata_html(msg: dict[str, Any]) -> str:
     """Build an HTML metadata header for email message.
 
-    Renders From, To, Subject, Date, Priority, and Read status
+    Renders From, To, Subject, Date, Priority, Read status, and Folder
     as a styled panel above the message body in HTML view.
 
     Args:
@@ -97,6 +115,10 @@ def _build_metadata_html(msg: dict[str, Any]) -> str:
         (
             tr_multi("Stato:", "Status:", "\u00c9tat:"),
             read_label if legita else unread_label,
+        ),
+        (
+            tr_multi("Dosierujo:", "Folder:", "Dossier:"),
+            str(msg.get("dosierujo_nomo", "") or ""),
         ),
     ]
     for label, value in fields:
@@ -135,6 +157,10 @@ def retposto_vidi_mesago(
     svc = get_retposto_service()
     msg = _resolve_message(svc, uuid)
 
+    # Enrich message with folder display name
+    if "dosierujo_nomo" not in msg or not msg["dosierujo_nomo"]:
+        msg["dosierujo_nomo"] = _lookup_folder_name(svc, msg.get("dosierujo_id", ""))
+
     # Mark as read
     svc.mark_read(msg["uuid"])
 
@@ -168,6 +194,8 @@ def retposto_vidi_mesago(
         return
 
     # Build email text
+    raw_nomo = msg.get("dosierujo_nomo", "") or ""
+    folder_label = raw_nomo or _lookup_folder_name(svc, msg.get("dosierujo_id", ""))
     lines = [
         f"From: {msg.get('de', '')}",
         f"To: {msg.get('al', '')}",
@@ -175,6 +203,7 @@ def retposto_vidi_mesago(
         f"Date: {msg.get('ricevita_je', '')}",
         f"Priority: {msg.get('prioritato', 5)}",
         f"Read: {'Yes' if msg.get('legita') else 'No'}",
+        f"Folder: {folder_label}",
         "-" * 40,
         "",
     ]

--- a/src/A_lien/data/storage.py
+++ b/src/A_lien/data/storage.py
@@ -13,6 +13,8 @@ Design decisions:
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from A.core.paths import data_dir
 from A.core.paths import ensure_dirs as _ensure_dirs
 from A.core.backup_targets import BackupTarget
@@ -316,9 +318,9 @@ KONTAKTOJ_FTS_CONFIG = FTSConfig(
 # ── Database initialization ──────────────────────────────────────────────────
 
 
-def _path() -> str:
+def _path() -> Path:
     """Get database path using A.core.paths."""
-    return str(data_dir() / "lien.db")
+    return data_dir() / "lien.db"
 
 
 def ensure_dirs() -> None:
@@ -326,7 +328,7 @@ def ensure_dirs() -> None:
     _ensure_dirs()
 
 
-def get_db(path: str | None = None) -> SQLiteDB:
+def get_db(path: Path | str | None = None) -> SQLiteDB:
     """Get database connection with all tables created and migrations applied.
 
     Args:
@@ -336,7 +338,8 @@ def get_db(path: str | None = None) -> SQLiteDB:
         SQLiteDB instance with schema + migrations applied
     """
     ensure_dirs()
-    db = SQLiteDB(path or _path())
+    resolved = Path(path) if path else _path()
+    db = SQLiteDB(resolved)
 
     for stmt in _SCHEMA_STATEMENTS:
         db.execute(stmt)

--- a/src/A_lien/service/retposto_messaging.py
+++ b/src/A_lien/service/retposto_messaging.py
@@ -69,55 +69,72 @@ class RetpostoMessagingMixin:
     def search_messages(
         self, filters: dict[str, Any], limit: int = 50
     ) -> list[dict[str, Any]]:
-        """Search messages with filters."""
+        """Search messages with filters.
+
+        Returns messages with an extra ``dosierujo_nomo`` key containing
+        the folder display name (or empty string if unknown).
+        """
         conditions = []
         params = []
         if filters.get("query"):
-            conditions.append("(subjekto LIKE ? OR korpo LIKE ?)")
+            conditions.append("(m.subjekto LIKE ? OR m.korpo LIKE ?)")
             q = f"%{filters['query']}%"
             params.extend([q, q])
         if filters.get("from"):
-            conditions.append("de LIKE ?")
+            conditions.append("m.de LIKE ?")
             params.append(f"%{filters['from']}%")
         if filters.get("to"):
-            conditions.append("al LIKE ?")
+            conditions.append("m.al LIKE ?")
             params.append(f"%{filters['to']}%")
         if filters.get("cc"):
-            conditions.append("kc LIKE ?")
+            conditions.append("m.kc LIKE ?")
             params.append(f"%{filters['cc']}%")
         if filters.get("bcc"):
-            conditions.append("bkc LIKE ?")
+            conditions.append("m.bkc LIKE ?")
             params.append(f"%{filters['bcc']}%")
         if filters.get("subject"):
-            conditions.append("subjekto LIKE ?")
+            conditions.append("m.subjekto LIKE ?")
             params.append(f"%{filters['subject']}%")
         if filters.get("body"):
-            conditions.append("korpo LIKE ?")
+            conditions.append("m.korpo LIKE ?")
             params.append(f"%{filters['body']}%")
         if filters.get("after"):
-            conditions.append("ricevita_je >= ?")
+            conditions.append("m.ricevita_je >= ?")
             params.append(filters["after"])
         if filters.get("before"):
-            conditions.append("ricevita_je <= ?")
+            conditions.append("m.ricevita_je <= ?")
             params.append(filters["before"])
         if filters.get("read") is not None:
-            conditions.append("legita = ?")
+            conditions.append("m.legita = ?")
             params.append(1 if filters["read"] else 0)
         if filters.get("priority"):
-            conditions.append("prioritato = ?")
+            conditions.append("m.prioritato = ?")
             params.append(filters["priority"])
         if filters.get("account"):
-            conditions.append("konto_id = ?")
+            conditions.append("m.konto_id = ?")
             params.append(filters["account"])
-        if conditions:
-            where = " AND ".join(conditions)
-            sql = f"SELECT * FROM mesagoj WHERE {where} AND forigita = 0 ORDER BY ricevita_je DESC LIMIT ?"
-        else:
-            sql = "SELECT * FROM mesagoj WHERE forigita = 0 ORDER BY ricevita_je DESC LIMIT ?"
+        if filters.get("folder"):
+            conditions.append(
+                "m.dosierujo_id IN (SELECT uuid FROM dosierujoj WHERE nomo = ?)"
+            )
+            params.append(filters["folder"])
+        base_where = " AND ".join(conditions) if conditions else "1"
+        sql = (
+            "SELECT m.*, COALESCE(d.nomo, '') AS dosierujo_nomo"
+            " FROM mesagoj m"
+            " LEFT JOIN dosierujoj d ON m.dosierujo_id = d.uuid"
+            f" WHERE {base_where} AND m.forigita = 0"
+            " ORDER BY m.ricevita_je DESC LIMIT ?"
+        )
         params.append(limit)
         try:
             rows = self.db.execute(sql, tuple(params))
         except Exception:
-            sql = "SELECT * FROM mesagoj WHERE forigita = 0 ORDER BY ricevita_je DESC LIMIT ?"
-            rows = self.db.execute(sql, (limit,))
+            fallback_sql = (
+                "SELECT m.*, '' AS dosierujo_nomo"
+                " FROM mesagoj m"
+                " WHERE m.forigita = 0"
+                " ORDER BY m.ricevita_je DESC LIMIT ?"
+            )
+            rows = self.db.execute(fallback_sql, (limit,))
         return list(rows)

--- a/src/A_lien/service/retposto_sync.py
+++ b/src/A_lien/service/retposto_sync.py
@@ -106,8 +106,16 @@ class RetpostoSyncMixin:
         """Insert or update a message in mesagoj table."""
         return store_message(self.db, data, force=force)
 
-    def sync_account(self, uuid: str, force: bool = False) -> Any:
-        """Sync messages for a single account."""
+    def sync_account(self, uuid: str, force: bool = False,
+                     folders: list[str] | None = None) -> Any:
+        """Sync messages for a single account.
+
+        Args:
+            uuid: Account UUID.
+            force: Re-download all messages if True.
+            folders: If given, only sync these folder names (e.g. ``["INBOX"]``).
+                     If None, sync all discovered folders.
+        """
         from A_lien.imap import sync_account as _sync
         acct = self.get_account_with_password(uuid)
         if not acct or "password" not in acct:
@@ -117,6 +125,7 @@ class RetpostoSyncMixin:
             use_ssl=acct.get("imap_ssl", 1) == 1,
             username=acct.get("imap_uzantonomo", "") or acct.get("retposto", ""),
             password=acct["password"], konto_id=uuid, db_store=self, force=force,
+            folders=folders,
         )
         backlog_count = self.process_sync_backlog()
         if backlog_count > 0:

--- a/tests/test_retposto_cli.py
+++ b/tests/test_retposto_cli.py
@@ -1,0 +1,176 @@
+"""CLI tests for retposto folder features (serci --dosierujo, preni --dosierujo)."""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+from unittest.mock import patch
+
+from A_lien.cli.retposto import retposto
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def isolate_lien(monkeypatch, tmp_path):
+    """Isolate DB and keyring for retposto CLI tests."""
+    from A.core.testing import patch_paths, patch_keyring
+    patch_paths(monkeypatch, tmp_path)
+    patch_keyring(monkeypatch)
+    import A_lien.service.retposto_service as rp
+    rp._retposto_service = None
+
+
+class TestSerciDosierujo:
+    """Tests for serci --dosierujo CLI option."""
+
+    def test_serci_help_shows_dosierujo(self, runner):
+        """--help output mentions --dosierujo option."""
+        result = runner.invoke(retposto, ["serci", "--help"])
+        assert result.exit_code == 0
+        assert "--dosierujo" in result.stdout
+
+    def test_serci_with_folder_passes_to_service(self, runner, monkeypatch):
+        """serci --dosierujo passes folder to search_messages."""
+        from A_lien.service import get_retposto_service
+        svc = get_retposto_service()
+
+        captured = {}
+
+        def mock_search(filters, limit=50):
+            captured["filters"] = filters
+            captured["limit"] = limit
+            return []
+
+        monkeypatch.setattr(svc, "search_messages", mock_search)
+
+        result = runner.invoke(retposto, [
+            "serci", "hello", "--dosierujo", "INBOX",
+        ])
+        assert result.exit_code == 0
+        assert captured["filters"].get("folder") == "INBOX"
+        assert captured["filters"].get("query") == "hello"
+
+    def test_serci_folder_alone_no_query(self, runner, monkeypatch):
+        """serci --dosierujo works without query argument."""
+        from A_lien.service import get_retposto_service
+        svc = get_retposto_service()
+
+        captured = {}
+
+        def mock_search(filters, limit=50):
+            captured["filters"] = filters
+            return []
+
+        monkeypatch.setattr(svc, "search_messages", mock_search)
+
+        result = runner.invoke(retposto, [
+            "serci", "--dosierujo", "Sent",
+        ])
+        assert result.exit_code == 0
+        assert captured["filters"].get("folder") == "Sent"
+
+    def test_format_results_shows_folder(self, service_with_data, runner):
+        """_format_results output includes folder name when present."""
+        from A_lien.cli.retposto_search import _format_results
+
+        results = [
+            {
+                "uuid": "abc-def-123",
+                "subjekto": "Test message",
+                "legita": 1,
+                "dosierujo_nomo": "INBOX",
+            },
+        ]
+        lines = _format_results(results)
+        combined = " ".join(lines)
+        assert "[INBOX]" in combined
+
+    def test_format_results_no_folder(self, runner):
+        """_format_results works without dosierujo_nomo key."""
+        from A_lien.cli.retposto_search import _format_results
+
+        results = [
+            {
+                "uuid": "abc-def-123",
+                "subjekto": "Test message",
+                "legita": 0,
+            },
+        ]
+        lines = _format_results(results)
+        combined = " ".join(lines)
+        # No folder bracket when folder is unknown
+        assert "Test message" in combined
+
+
+class TestPreniDosierujo:
+    """Tests for preni --dosierujo CLI option."""
+
+    def test_preni_help_shows_dosierujo(self, runner):
+        """--help output mentions --dosierujo option."""
+        result = runner.invoke(retposto, ["preni", "--help"])
+        assert result.exit_code == 0
+        assert "--dosierujo" in result.stdout
+
+    def test_preni_dosierujo_without_konto_errors(self, runner, monkeypatch):
+        """--dosierujo without --konto shows error."""
+        # Mock sync_all to not actually connect to IMAP
+        monkeypatch.setattr(
+            "A_lien.service.retposto_service.RetpostoService.list_accounts",
+            lambda self: [],
+        )
+
+        result = runner.invoke(retposto, [
+            "preni", "--dosierujo", "INBOX",
+        ])
+        assert result.exit_code != 0
+        assert "postulas" in result.stdout.lower() or "requires" in result.stdout.lower()
+
+    def test_preni_dosierujo_with_konto_calls_sync(self, runner, monkeypatch):
+        """--dosierujo with --konto passes folders to sync_account."""
+        import uuid as uuid_mod
+        from A_lien.service import get_retposto_service
+
+        svc = get_retposto_service()
+        svc.get_password = lambda uuid: "sekret123"  # type: ignore[method-assign]
+
+        # Create a real account in the DB
+        acct_uuid = str(uuid_mod.uuid4())
+        now = "2026-01-01T00:00:00"
+        svc.db.execute(
+            "INSERT INTO kontoj (uuid, nomo, retposto, imap_servilo, imap_haveno, "
+            "imap_ssl, smtp_servilo, smtp_haveno, smtp_tls, kreita_je, modifita_je) "
+            "VALUES (?, 'Test', 'test@example.com', 'imap.test.com', 993, 1, "
+            "'smtp.test.com', 587, 1, ?, ?)",
+            (acct_uuid, now, now),
+        )
+
+        captured = {}
+
+        def mock_sync_account(uuid, force=False, folders=None):
+            captured["uuid"] = uuid
+            captured["folders"] = folders
+            from A_lien.imap._sync_types import SyncResult
+            return SyncResult()
+
+        monkeypatch.setattr(svc, "sync_account", mock_sync_account)
+
+        result = runner.invoke(retposto, [
+            "preni", "--konto", acct_uuid[:8],
+            "--dosierujo", "INBOX",
+        ])
+        assert result.exit_code == 0
+        assert captured["folders"] == ["INBOX"]
+        assert captured["uuid"] == acct_uuid
+
+
+@pytest.fixture
+def service_with_data():
+    """Fixture that provides a service with seeded data for display tests."""
+    from A_lien.service import get_retposto_service
+    svc = get_retposto_service()
+    # Seed minimal data needed for _format_results display
+    return svc

--- a/tests/test_retposto_service.py
+++ b/tests/test_retposto_service.py
@@ -248,6 +248,231 @@ class TestSignatures:
         assert resolved["nomo"] == uuid_like_name
 
 
+# ── Search messages with folder filter ───────────────────────────────────────
+
+
+class TestSearchMessagesFolder:
+    """Tests for folder filter and folder name in search results."""
+
+    def _seed_folder_and_messages(self, service):
+        """Seed test data: 1 account, 2 folders (INBOX, Sent), 2 msgs each."""
+        import uuid as uuid_mod
+
+        konto_id = str(uuid_mod.uuid4())
+        now = "2026-01-01T00:00:00"
+
+        # Create a real account (satisfies FOREIGN KEY)
+        service.db.execute(
+            "INSERT INTO kontoj (uuid, nomo, retposto, imap_servilo, imap_haveno, "
+            "imap_ssl, smtp_servilo, smtp_haveno, smtp_tls, kreita_je, modifita_je) "
+            "VALUES (?, 'Test User', 'test@example.com', 'imap.test.com', 993, 1, "
+            "'smtp.test.com', 587, 1, ?, ?)",
+            (konto_id, now, now),
+        )
+
+        # Create two folders
+        folder_inbox_uuid = str(uuid_mod.uuid4())
+        folder_sent_uuid = str(uuid_mod.uuid4())
+        service.db.execute(
+            "INSERT INTO dosierujoj (uuid, konto_id, nomo, kreita_je, modifita_je) "
+            "VALUES (?, ?, 'INBOX', ?, ?)",
+            (folder_inbox_uuid, konto_id, now, now),
+        )
+        service.db.execute(
+            "INSERT INTO dosierujoj (uuid, konto_id, nomo, kreita_je, modifita_je) "
+            "VALUES (?, ?, 'Sent', ?, ?)",
+            (folder_sent_uuid, konto_id, now, now),
+        )
+
+        # Insert messages
+        for uid, fld_uuid, subj in [
+            (str(uuid_mod.uuid4()), folder_inbox_uuid, "Hello INBOX 1"),
+            (str(uuid_mod.uuid4()), folder_inbox_uuid, "Hello INBOX 2"),
+            (str(uuid_mod.uuid4()), folder_sent_uuid, "Hello Sent 1"),
+            (str(uuid_mod.uuid4()), folder_sent_uuid, "Hello Sent 2"),
+        ]:
+            service.db.execute(
+                "INSERT INTO mesagoj (uuid, konto_id, dosierujo_id, subjekto, "
+                "kreita_je, modifita_je) VALUES (?, ?, ?, ?, ?, ?)",
+                (uid, konto_id, fld_uuid, subj, now, now),
+            )
+
+        return konto_id
+
+    def test_folder_filter(self, service):
+        """search_messages with folder filter returns only matching messages."""
+        self._seed_folder_and_messages(service)
+
+        results = service.search_messages({"folder": "INBOX"}, limit=50)
+        assert len(results) == 2
+        assert all("INBOX 1" in r["subjekto"] or "INBOX 2" in r["subjekto"]
+                   for r in results)
+        assert all(r["dosierujo_nomo"] == "INBOX" for r in results)
+
+    def test_folder_filter_sent(self, service):
+        """search_messages with folder='Sent' returns only Sent messages."""
+        self._seed_folder_and_messages(service)
+
+        results = service.search_messages({"folder": "Sent"}, limit=50)
+        assert len(results) == 2
+        assert all("Sent" in r["subjekto"] for r in results)
+        assert all(r["dosierujo_nomo"] == "Sent" for r in results)
+
+    def test_folder_filter_nonexistent(self, service):
+        """search_messages with nonexistent folder name returns empty."""
+        self._seed_folder_and_messages(service)
+
+        results = service.search_messages({"folder": "Nonexistent"}, limit=50)
+        assert len(results) == 0
+
+    def test_no_folder_filter_returns_all(self, service):
+        """search_messages without folder filter returns all messages."""
+        self._seed_folder_and_messages(service)
+
+        results = service.search_messages({}, limit=50)
+        assert len(results) == 4
+
+    def test_dosierujo_nomo_in_results(self, service):
+        """search_messages results include dosierujo_nomo key."""
+        self._seed_folder_and_messages(service)
+
+        results = service.search_messages({}, limit=50)
+        for r in results:
+            assert "dosierujo_nomo" in r
+            assert r["dosierujo_nomo"] in ("INBOX", "Sent")
+
+    def test_folder_filter_with_other_filters(self, service):
+        """Folder filter combines with other filters (e.g. query)."""
+        self._seed_folder_and_messages(service)
+
+        results = service.search_messages(
+            {"folder": "INBOX", "query": "Hello"}, limit=50
+        )
+        assert len(results) == 2
+
+    def test_folder_filter_account_combined(self, service):
+        """Folder filter works alongside account filter."""
+        import uuid as uuid_mod
+        self._seed_folder_and_messages(service)
+
+        # Create a second account + message in INBOX
+        konto2 = str(uuid_mod.uuid4())
+        fld2 = str(uuid_mod.uuid4())
+        now = "2026-01-01T00:00:00"
+        service.db.execute(
+            "INSERT INTO kontoj (uuid, nomo, retposto, imap_servilo, imap_haveno, "
+            "imap_ssl, smtp_servilo, smtp_haveno, smtp_tls, kreita_je, modifita_je) "
+            "VALUES (?, 'Other User', 'other@example.com', 'imap.test.com', 993, 1, "
+            "'smtp.test.com', 587, 1, ?, ?)",
+            (konto2, now, now),
+        )
+        service.db.execute(
+            "INSERT INTO dosierujoj (uuid, konto_id, nomo, kreita_je, modifita_je) "
+            "VALUES (?, ?, 'INBOX', ?, ?)",
+            (fld2, konto2, now, now),
+        )
+        service.db.execute(
+            "INSERT INTO mesagoj (uuid, konto_id, dosierujo_id, subjekto, "
+            "kreita_je, modifita_je) VALUES (?, ?, ?, 'Other account', ?, ?)",
+            (str(uuid_mod.uuid4()), konto2, fld2, now, now),
+        )
+
+        results = service.search_messages({"folder": "INBOX", "account": konto2}, limit=50)
+        assert len(results) == 1
+        assert results[0]["subjekto"] == "Other account"
+
+
+# ── SyncAccount with folders parameter ──────────────────────────────────────
+
+
+class TestSyncAccountFolders:
+    """Tests for sync_account folders parameter."""
+
+    def test_sync_account_accepts_folders(self, service, monkeypatch):
+        """sync_account passes folders parameter to IMAP sync."""
+        import uuid as uuid_mod
+
+        acct_uuid = str(uuid_mod.uuid4())
+        now = "2026-01-01T00:00:00"
+        service.db.execute(
+            "INSERT INTO kontoj (uuid, nomo, retposto, imap_servilo, imap_haveno, "
+            "imap_ssl, smtp_servilo, smtp_haveno, smtp_tls, kreita_je, modifita_je) "
+            "VALUES (?, 'Test', 'test@example.com', 'imap.test.com', 993, 1, "
+            "'smtp.test.com', 587, 1, ?, ?)",
+            (acct_uuid, now, now),
+        )
+
+        # Mock password retrieval
+        monkeypatch.setattr(service, "get_password", lambda uuid: "sekret123")
+        monkeypatch.setattr(service, "get_account_with_password", lambda uuid: {
+            "uuid": acct_uuid,
+            "imap_servilo": "imap.test.com",
+            "imap_haveno": 993,
+            "imap_ssl": 1,
+            "imap_uzantonomo": "test@example.com",
+            "retposto": "test@example.com",
+            "password": "sekret123",
+        })
+
+        # Mock the low-level IMAP sync to verify folders parameter
+        captured = {}
+
+        def mock_sync(host=None, port=None, use_ssl=None, username=None,
+                      password=None, konto_id=None, db_store=None,
+                      folders=None, force=False):
+            captured["folders"] = folders
+            from A_lien.imap._sync_types import SyncResult
+            return SyncResult()
+
+        monkeypatch.setattr("A_lien.imap.sync_account", mock_sync)
+
+        # Patch svc.process_sync_backlog to avoid actual IMAP
+        monkeypatch.setattr(service, "process_sync_backlog", lambda: 0)
+
+        # Call with folders
+        service.sync_account(acct_uuid, folders=["INBOX"])
+        assert captured.get("folders") == ["INBOX"]
+
+    def test_sync_account_folders_default_none(self, service, monkeypatch):
+        """sync_account passes folders=None by default (all folders)."""
+        import uuid as uuid_mod
+
+        acct_uuid = str(uuid_mod.uuid4())
+        now = "2026-01-01T00:00:00"
+        service.db.execute(
+            "INSERT INTO kontoj (uuid, nomo, retposto, imap_servilo, imap_haveno, "
+            "imap_ssl, smtp_servilo, smtp_haveno, smtp_tls, kreita_je, modifita_je) "
+            "VALUES (?, 'Test', 'test@example.com', 'imap.test.com', 993, 1, "
+            "'smtp.test.com', 587, 1, ?, ?)",
+            (acct_uuid, now, now),
+        )
+        monkeypatch.setattr(service, "get_password", lambda uuid: "sekret123")
+        monkeypatch.setattr(service, "get_account_with_password", lambda uuid: {
+            "uuid": acct_uuid,
+            "imap_servilo": "imap.test.com",
+            "imap_haveno": 993,
+            "imap_ssl": 1,
+            "imap_uzantonomo": "test@example.com",
+            "retposto": "test@example.com",
+            "password": "sekret123",
+        })
+
+        captured = {}
+
+        def mock_sync(host=None, port=None, use_ssl=None, username=None,
+                      password=None, konto_id=None, db_store=None,
+                      folders=None, force=False):
+            captured["folders"] = folders
+            from A_lien.imap._sync_types import SyncResult
+            return SyncResult()
+
+        monkeypatch.setattr("A_lien.imap.sync_account", mock_sync)
+        monkeypatch.setattr(service, "process_sync_backlog", lambda: 0)
+
+        service.sync_account(acct_uuid)
+        assert captured.get("folders") is None
+
+
 # ── Singleton ────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -195,7 +195,7 @@ class TestMigrate:
         from A.data.base import SQLiteDB
         from A_lien.data.storage import _SCHEMA_STATEMENTS
 
-        db_path = str(tmp_path / "test_pre_migrate.db")
+        db_path = tmp_path / "test_pre_migrate.db"
         db = SQLiteDB(db_path)
         for stmt in _SCHEMA_STATEMENTS:
             db.execute(stmt)
@@ -234,7 +234,7 @@ class TestMigrate:
         from A.data.base import SQLiteDB
 
         # Build a legacy mesagoj table (old schema with uid TEXT)
-        db_path = str(tmp_path / "test_legacy.db")
+        db_path = tmp_path / "test_legacy.db"
         db = SQLiteDB(db_path)
         db.execute("""
             CREATE TABLE IF NOT EXISTS mesagoj (
@@ -278,7 +278,7 @@ class TestMigrate:
         # Now run get_db() — this should NOT crash (the bug)
         from A_lien.data.storage import get_db
 
-        db2 = get_db(str(tmp_path / "test_legacy.db"))
+        db2 = get_db(tmp_path / "test_legacy.db")
 
         # Verify the new column exists
         cols = {


### PR DESCRIPTION
## Summary

Adds folder (dosierujo) awareness to email search and sync commands.

### Changes

**serci (search):**
- New `--dosierujo/-d` option to filter results by folder name
- Folder name shown as `[INBOX]`, `[Sent]`, etc. in search output
- Service-layer `search_messages()` now LEFT JOINs `dosierujoj` to return `dosierujo_nomo`

**preni (fetch):**
- New `--dosierujo/-f` option for selective folder sync (requires `--konto`)
- Passes through to IMAP sync engine via `folders` parameter

**vidi (view):**
- Shows `Folder:` line in text and HTML message views

**Bug fixes:**
- `storage.py:_path()` returned `str` instead of `Path`
- `storage.py:get_db()` passed string to `SQLiteDB` instead of `Path`
- Test storage helpers passed `str()` path to `SQLiteDB`
- A-core base.py missing `data_dir` import (separate commit in A-core repo)

### Testing
- 17 new tests: 7 service-level folder filter + 2 sync folders param + 8 CLI
- All 160 tests pass
- User simulation verified filtering, error cases, output format