### PR TITLE
feat: retposto elsuti --stdout for LLM-readable attachment content

### DIFF
--- a/src/A_lien/cli/retposto_elsuti.py
+++ b/src/A_lien/cli/retposto_elsuti.py
@@ -1,6 +1,7 @@
 """Retposto attachment download — elsuti.
 
-Download/extract attachment(s) from an email via IMAP.
+Download/extract attachment(s) from an email via IMAP,
+or print text-type attachment content to stdout.
 """
 
 from __future__ import annotations
@@ -13,6 +14,46 @@ from A import confirm_action, error, info, tr_multi
 from A_lien.cli.retposto_message_ops import _resolve_message
 from A_lien.service import get_retposto_service
 
+# MIME types whose content can safely be printed as text.
+_TEXT_MIME_PREFIXES: frozenset[str] = frozenset({
+    "text/",
+})
+
+_TEXT_MIME_EXACT: frozenset[str] = frozenset({
+    "application/json",
+    "application/xml",
+    "application/xhtml+xml",
+    "application/atom+xml",
+    "application/rss+xml",
+    "application/javascript",
+    "application/ecmascript",
+    "application/x-yaml",
+    "application/toml",
+    "application/csv",
+    "application/x-csv",
+    "application/x-httpd-php",
+    "application/x-sh",
+    "application/sql",
+})
+
+
+def _is_text_mime(mime: str) -> bool:
+    """Check whether a MIME type is text-like and safe to print inline.
+
+    Args:
+        mime: The MIME type string (e.g. ``"text/plain"``, ``"application/pdf"``).
+
+    Returns:
+        True if the content can be decoded as readable text.
+    """
+    mime_lower = mime.strip().lower()
+    if mime_lower in _TEXT_MIME_EXACT:
+        return True
+    for prefix in _TEXT_MIME_PREFIXES:
+        if mime_lower.startswith(prefix):
+            return True
+    return False
+
 
 def _fmt_size(size: int) -> str:
     """Format byte count to human-readable string."""
@@ -21,6 +62,68 @@ def _fmt_size(size: int) -> str:
     if size > 1024:
         return f"{size / 1024:.1f} KB"
     return f"{size} B"
+
+
+# ── stdout-mode helpers ──────────────────────────────────────────────────────
+
+
+def _try_decode(data: bytes) -> str | None:
+    """Try to decode bytes as UTF-8 text.
+
+    Args:
+        data: Raw bytes.
+
+    Returns:
+        Decoded string, or None if the data is not valid UTF-8.
+    """
+    try:
+        return data.decode("utf-8")
+    except (UnicodeDecodeError, UnicodeError):
+        return None
+
+
+def _print_text_attachment(svc: object, msg_uuid: str, att: dict) -> None:
+    """Fetch a text attachment and print its content to stdout.
+
+    Args:
+        svc: RetpostoService instance.
+        msg_uuid: Message UUID.
+        att: Attachment metadata dict (must contain ``dosiernomo`` and ``mime_tipo``).
+    """
+    fname = att.get("dosiernomo", "?")
+    mime = att.get("mime_tipo", "") or "application/octet-stream"
+
+    try:
+        raw: bytes = svc.get_attachment_content(msg_uuid, fname)  # type: ignore[arg-type]
+    except Exception as e:
+        info(tr_multi(
+            f"  [eraro] {fname}: {e}",
+            f"  [error] {fname}: {e}",
+            f"  [erreur] {fname} : {e}",
+        ))
+        return
+
+    text = _try_decode(raw)
+    if text is None:
+        info(tr_multi(
+            f"  [binary] {fname} ({mime}) — enhavo ne estas valida UTF-8; uzu --output por konservi",
+            f"  [binary] {fname} ({mime}) — content is not valid UTF-8; use --output to save",
+            f"  [binaire] {fname} ({mime}) — le contenu n'est pas en UTF-8 valide; utilisez --output",
+        ))
+        return
+
+    # Truncation guard: if content is huge, print first and last N chars
+    MAX_STDOUT_CHARS = 50_000
+    if len(text) > MAX_STDOUT_CHARS:
+        info(f"--- {fname} ({_fmt_size(len(raw))}) — {tr_multi('montras unuajn', 'showing first', 'affiche les premiers')} {MAX_STDOUT_CHARS} {tr_multi('signojn', 'chars', 'caractères')} ---")
+        info(text[:MAX_STDOUT_CHARS])
+        info("... " + tr_multi("(tranĉita)", "(truncated)", "(tronqué)"))
+    else:
+        info(f"--- {fname} ({_fmt_size(len(raw))}) ---")
+        info(text)
+
+
+# ── Main command ─────────────────────────────────────────────────────────────
 
 
 def retposto_elsuti(
@@ -46,14 +149,23 @@ def retposto_elsuti(
             "Dossier de sortie (d\u00e9faut: /tmp/)",
         ),
     ),
+    stdout: bool = typer.Option(
+        False, "--stdout",
+        help=tr_multi(
+            "Presi tekstan enhavon al stdout (anstata\u016d konservi)",
+            "Print text content to stdout (instead of saving to disk)",
+            "Imprimer le contenu texte sur stdout (au lieu de sauvegarder)",
+        ),
+    ),
 ) -> None:
     """Download attachment(s) from a message via IMAP.
 
     If no filename is given, downloads ALL attachments
     (with confirmation if >3 files or >10 MB total).
-    """
-    import os
 
+    Use --stdout to print text-type attachment content directly
+    to stdout instead of saving to disk.
+    """
     svc = get_retposto_service()
     msg = _resolve_message(svc, uuid)
     if not msg:
@@ -73,10 +185,68 @@ def retposto_elsuti(
         ))
         return
 
+    # ── stdout mode: print text content inline ────────────────────────────
+    if stdout:
+        if filename:
+            # Single attachment
+            matching = [a for a in attachments if a.get("dosiernomo") == filename]
+            if not matching:
+                error(tr_multi(
+                    f"Aldona\u0135o '{filename}' ne trovita.",
+                    f"Attachment '{filename}' not found.",
+                    f"Pi\u00e8ce jointe '{filename}' non trouv\u00e9e.",
+                ))
+                raise typer.Exit(1)
+            att = matching[0]
+            mime = att.get("mime_tipo", "") or "application/octet-stream"
+            if _is_text_mime(mime):
+                _print_text_attachment(svc, msg["uuid"], att)
+            else:
+                info(tr_multi(
+                    f"[binary] {filename} ({mime}) — ne eblas montri kiel teksto; uzu --output por konservi",
+                    f"[binary] {filename} ({mime}) — cannot display as text; use --output to save",
+                    f"[binaire] {filename} ({mime}) — ne peut pas \u00eatre affich\u00e9 comme texte; utilisez --output",
+                ))
+            return
+
+        # All attachments in stdout mode
+        text_count = 0
+        binary_count = 0
+        for att in attachments:
+            fname = att.get("dosiernomo", "?")
+            mime = att.get("mime_tipo", "") or "application/octet-stream"
+            if _is_text_mime(mime):
+                _print_text_attachment(svc, msg["uuid"], att)
+                text_count += 1
+            else:
+                info(tr_multi(
+                    f"--- {fname} ({mime}) — [binary] ne montrebla kiel teksto ---",
+                    f"--- {fname} ({mime}) — [binary] not displayable as text ---",
+                    f"--- {fname} ({mime}) — [binaire] non affichable comme texte ---",
+                ))
+                binary_count += 1
+
+        if text_count:
+            info(tr_multi(
+                f"Montris {text_count} tekstan(j)n aldona\u0135o(j)n.",
+                f"Displayed {text_count} text attachment(s).",
+                f"{text_count} pi\u00e8ce(s) jointe(s) texte affich\u00e9e(s).",
+            ))
+        if binary_count:
+            info(tr_multi(
+                f"{binary_count} aldona\u0135o(j) estas en ne-teksta formato; uzu --output por konservi.",
+                f"{binary_count} attachment(s) are in non-text format; use --output to save.",
+                f"{binary_count} pi\u00e8ce(s) jointe(s) sont en format non-texte; utilisez --output.",
+            ))
+        return
+
+    # ── Save-to-disk mode (original behaviour) ────────────────────────────
+    import os
+
     out = output_dir or "/tmp"
 
     if filename:
-        # ── Single attachment ─────────────────────────────────────────────
+        # Single attachment download
         if not any(a.get("dosiernomo") == filename for a in attachments):
             error(tr_multi(
                 f"Aldona\u0135o '{filename}' ne trovita.",
@@ -92,7 +262,7 @@ def retposto_elsuti(
             raise typer.Exit(1)
         return
 
-    # ── Download all ──────────────────────────────────────────────────────
+    # Download all attachments
     total_size = sum(a.get("grandeco", 0) for a in attachments)
     total_mb = total_size / (1024 * 1024)
 

--- a/tests/test_elsuti.py
+++ b/tests/test_elsuti.py
@@ -1,0 +1,282 @@
+"""Tests for A-lien retposto_elsuti — attachment download and --stdout mode.
+
+Tests the CLI command, the _is_text_mime helper, and _try_decode.
+Does NOT test actual IMAP attachment fetching (requires network).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from A_lien.cli import app
+
+
+# ---------------------------------------------------------------------------
+# _is_text_mime helper
+# ---------------------------------------------------------------------------
+
+class TestIsTextMime:
+    def test_text_plain(self):
+        from A_lien.cli.retposto_elsuti import _is_text_mime
+        assert _is_text_mime("text/plain")
+
+    def test_text_html(self):
+        from A_lien.cli.retposto_elsuti import _is_text_mime
+        assert _is_text_mime("text/html")
+
+    def test_text_csv(self):
+        from A_lien.cli.retposto_elsuti import _is_text_mime
+        assert _is_text_mime("text/csv")
+
+    def test_application_json(self):
+        from A_lien.cli.retposto_elsuti import _is_text_mime
+        assert _is_text_mime("application/json")
+
+    def test_application_xml(self):
+        from A_lien.cli.retposto_elsuti import _is_text_mime
+        assert _is_text_mime("application/xml")
+
+    def test_application_pdf_is_binary(self):
+        from A_lien.cli.retposto_elsuti import _is_text_mime
+        assert not _is_text_mime("application/pdf")
+
+    def test_image_jpeg_is_binary(self):
+        from A_lien.cli.retposto_elsuti import _is_text_mime
+        assert not _is_text_mime("image/jpeg")
+
+    def test_application_zip_is_binary(self):
+        from A_lien.cli.retposto_elsuti import _is_text_mime
+        assert not _is_text_mime("application/zip")
+
+    def test_application_octet_stream_is_binary(self):
+        from A_lien.cli.retposto_elsuti import _is_text_mime
+        assert not _is_text_mime("application/octet-stream")
+
+    def test_empty_mime(self):
+        from A_lien.cli.retposto_elsuti import _is_text_mime
+        assert not _is_text_mime("")
+
+    def test_case_insensitive(self):
+        from A_lien.cli.retposto_elsuti import _is_text_mime
+        assert _is_text_mime("TEXT/PLAIN")
+        assert _is_text_mime("Application/JSON")
+
+    def test_yaml_and_toml(self):
+        from A_lien.cli.retposto_elsuti import _is_text_mime
+        assert _is_text_mime("application/x-yaml")
+        assert _is_text_mime("application/toml")
+
+    def test_shell_script(self):
+        from A_lien.cli.retposto_elsuti import _is_text_mime
+        assert _is_text_mime("application/x-sh")
+
+    def test_sql(self):
+        from A_lien.cli.retposto_elsuti import _is_text_mime
+        assert _is_text_mime("application/sql")
+
+
+# ---------------------------------------------------------------------------
+# _try_decode helper
+# ---------------------------------------------------------------------------
+
+
+class TestTryDecode:
+    def test_utf8_text(self):
+        from A_lien.cli.retposto_elsuti import _try_decode
+        result = _try_decode("Hello, world!".encode("utf-8"))
+        assert result == "Hello, world!"
+
+    def test_utf8_with_special_chars(self):
+        from A_lien.cli.retposto_elsuti import _try_decode
+        result = _try_decode("Café résumé ñoño".encode("utf-8"))
+        assert result == "Café résumé ñoño"
+
+    def test_binary_bytes_returns_none(self):
+        from A_lien.cli.retposto_elsuti import _try_decode
+        result = _try_decode(b"\xff\xfe\x00\x01\x02\x03")
+        assert result is None
+
+    def test_empty_bytes(self):
+        from A_lien.cli.retposto_elsuti import _try_decode
+        result = _try_decode(b"")
+        assert result == ""
+
+    def test_invalid_utf8_sequence_returns_none(self):
+        from A_lien.cli.retposto_elsuti import _try_decode
+        # 0xFF is never valid in UTF-8
+        result = _try_decode(b"\xff")
+        assert result is None
+        # Overlong encoding is also invalid
+        result = _try_decode(b"\xc0\x80")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _print_text_attachment helper
+# ---------------------------------------------------------------------------
+
+
+class TestPrintTextAttachment:
+    def test_prints_text_content(self):
+        from A_lien.cli.retposto_elsuti import _print_text_attachment
+
+        svc = MagicMock()
+        svc.get_attachment_content.return_value = b"Hello, attachment!"
+
+        with patch("A_lien.cli.retposto_elsuti.info") as mock_info:
+            _print_text_attachment(svc, "msg-uuid", {
+                "dosiernomo": "readme.txt",
+                "mime_tipo": "text/plain",
+            })
+
+        # Should have printed the content
+        assert mock_info.call_count >= 1
+        # At least one call should contain the file content
+        all_calls = [str(c[0][0]) for c in mock_info.call_args_list]
+        combined = " ".join(all_calls)
+        assert "Hello, attachment!" in combined
+
+    def test_binary_content_shows_error(self):
+        from A_lien.cli.retposto_elsuti import _print_text_attachment
+
+        svc = MagicMock()
+        svc.get_attachment_content.return_value = b"\xff\xfe\x00\x01"
+
+        with patch("A_lien.cli.retposto_elsuti.info") as mock_info:
+            _print_text_attachment(svc, "msg-uuid", {
+                "dosiernomo": "data.bin",
+                "mime_tipo": "application/octet-stream",
+            })
+
+        # Should mention binary / non-UTF-8
+        all_calls = [str(c[0][0]) for c in mock_info.call_args_list]
+        combined = " ".join(all_calls)
+        assert "binary" in combined.lower() or "binaire" in combined.lower()
+
+    def test_large_content_truncated(self):
+        from A_lien.cli.retposto_elsuti import _print_text_attachment
+
+        svc = MagicMock()
+        svc.get_attachment_content.return_value = b"A" * 100_000
+
+        with patch("A_lien.cli.retposto_elsuti.info") as mock_info:
+            _print_text_attachment(svc, "msg-uuid", {
+                "dosiernomo": "large.txt",
+                "mime_tipo": "text/plain",
+            })
+
+        all_calls = [str(c[0][0]) for c in mock_info.call_args_list]
+        combined = " ".join(all_calls)
+        assert "truncated" in combined.lower() or "tran\u0109ita" in combined.lower() or "tronqu" in combined.lower()
+
+
+# ---------------------------------------------------------------------------
+# CLI command: --stdout flag
+# ---------------------------------------------------------------------------
+
+
+class TestElsutiStdout:
+    def test_stdout_flag_accepted(self):
+        """--stdout should be a valid option (returns 2 = usage error
+        because no arguments given, but not an 'Unknown option' error)."""
+        runner = CliRunner()
+        result = runner.invoke(app, ["retposto", "elsuti", "--stdout"])
+        # Exit code 2 means usage error (missing argument), not 'Unknown option'
+        assert result.exit_code == 2
+        assert "Unknown option" not in (result.stderr or "")
+
+    def test_stdout_no_attachments(self):
+        """When --stdout is used but the message has no attachments."""
+        from A_lien.service import get_retposto_service
+
+        svc = get_retposto_service()
+        # Mock: message exists but no attachments
+        with patch.object(svc, "get_message", return_value={"uuid": "abc12345"}), \
+             patch.object(svc, "get_attachments", return_value=[]), \
+             patch("A_lien.cli.retposto_elsuti.info") as mock_info:
+
+            runner = CliRunner()
+            result = runner.invoke(app, ["retposto", "elsuti", "abc12345", "--stdout"])
+
+        # Should succeed with "no attachments" message
+        assert result.exit_code == 0
+        all_calls = [str(c[0][0]) for c in mock_info.call_args_list]
+        combined = " ".join(all_calls)
+        assert "neniuj" in combined.lower() or "no" in combined.lower() or "aucune" in combined.lower()
+
+    def test_stdout_with_text_attachment(self):
+        """When --stdout is used and the message has a text attachment."""
+        from A_lien.service import get_retposto_service
+
+        svc = get_retposto_service()
+        attachments = [{
+            "dosiernomo": "notes.txt",
+            "mime_tipo": "text/plain",
+            "grandeco": 50,
+        }]
+
+        with patch.object(svc, "get_message", return_value={"uuid": "abc12345"}), \
+             patch.object(svc, "get_attachments", return_value=attachments), \
+             patch.object(svc, "get_attachment_content", return_value=b"Meeting notes content"), \
+             patch("A_lien.cli.retposto_elsuti.info") as mock_info:
+
+            runner = CliRunner()
+            result = runner.invoke(app, ["retposto", "elsuti", "abc12345", "--stdout"])
+
+        assert result.exit_code == 0
+        all_calls = [str(c[0][0]) for c in mock_info.call_args_list]
+        combined = " ".join(all_calls)
+        assert "Meeting notes content" in combined
+        assert "notes.txt" in combined
+
+    def test_stdout_with_binary_attachment(self):
+        """When --stdout is used with a binary attachment, show info message."""
+        from A_lien.service import get_retposto_service
+
+        svc = get_retposto_service()
+        attachments = [{
+            "dosiernomo": "chart.pdf",
+            "mime_tipo": "application/pdf",
+            "grandeco": 50_000,
+        }]
+
+        with patch.object(svc, "get_message", return_value={"uuid": "abc12345"}), \
+             patch.object(svc, "get_attachments", return_value=attachments), \
+             patch("A_lien.cli.retposto_elsuti.info") as mock_info:
+
+            runner = CliRunner()
+            result = runner.invoke(app, ["retposto", "elsuti", "abc12345", "--stdout"])
+
+        assert result.exit_code == 0
+        all_calls = [str(c[0][0]) for c in mock_info.call_args_list]
+        combined = " ".join(all_calls)
+        assert "binary" in combined.lower() or "binaire" in combined.lower()
+        assert "chart.pdf" in combined
+
+    def test_stdout_specific_filename(self):
+        """--stdout with a specific filename should print that attachment."""
+        from A_lien.service import get_retposto_service
+
+        svc = get_retposto_service()
+        attachments = [
+            {"dosiernomo": "notes.txt", "mime_tipo": "text/plain", "grandeco": 50},
+            {"dosiernomo": "data.csv", "mime_tipo": "text/csv", "grandeco": 100},
+        ]
+
+        with patch.object(svc, "get_message", return_value={"uuid": "abc12345"}), \
+             patch.object(svc, "get_attachments", return_value=attachments), \
+             patch.object(svc, "get_attachment_content", return_value=b"csv,data,here"), \
+             patch("A_lien.cli.retposto_elsuti.info") as mock_info:
+
+            runner = CliRunner()
+            result = runner.invoke(app, [
+                "retposto", "elsuti", "abc12345", "data.csv", "--stdout",
+            ])
+
+        assert result.exit_code == 0
+        all_calls = [str(c[0][0]) for c in mock_info.call_args_list]
+        combined = " ".join(all_calls)
+        assert "csv,data,here" in combined


### PR DESCRIPTION
## Summary

Add `--stdout` flag to `retposto elsuti` so the LLM (via A-kunpiloto's auto-injection) can read email attachment content inline.

### What it does
- **Text attachments** (`text/*`, `application/json`, `application/xml`, etc.): decoded as UTF-8 and printed to stdout with a size header
- **Binary attachments** (`application/pdf`, `image/*`, `application/zip`, etc.): prints a clear message that the content is binary and cannot be displayed as text
- **Large content** (>50 KB): truncated with a warning
- **Invalid UTF-8**: reported as binary

### How it works with A-kunpiloto
No changes needed in A-kunpiloto — the existing `_LLM_FORCE_FLAGS` set already contains `--stdout`, which means:
1. A-kunpiloto discovers `lien_retposto_elsuti` and sees `--stdout` option
2. `--stdout` is removed from the LLM-visible schema
3. The executor injects `stdout=True` by default
4. The LLM only needs to provide `uuid` and optionally `filename`

### Tests
27 new tests across the helpers and CLI integration.