### PR TITLE
feat: elsuti --stdout extracts PDF text via A-papero (single LLM tool call)

### DIFF
--- a/src/A_lien/cli/retposto_elsuti.py
+++ b/src/A_lien/cli/retposto_elsuti.py
@@ -55,6 +55,45 @@ def _is_text_mime(mime: str) -> bool:
     return False
 
 
+# Binary MIME types that we can extract text from (via optional A-papero).
+_EXTRACTABLE_BINARY_MIMES: frozenset[str] = frozenset({
+    "application/pdf",
+})
+
+
+def _is_extractable_binary(mime: str) -> bool:
+    """Check whether a binary MIME type supports text extraction.
+
+    Currently supported: PDF (requires ``A-papero[pdf]`` installed).
+
+    Args:
+        mime: The MIME type string.
+
+    Returns:
+        True if text extraction is possible with optional dependencies.
+    """
+    return mime.strip().lower() in _EXTRACTABLE_BINARY_MIMES
+
+
+def _try_extract_pdf_text(data: bytes) -> str | None:
+    """Try to extract text from PDF bytes using A-papero (optional dependency).
+
+    Attempts a runtime import from ``A_papero.formats.pdf``.  If A-papero
+    is not installed, returns ``None`` — the caller should suggest installing it.
+
+    Args:
+        data: Raw PDF bytes.
+
+    Returns:
+        Extracted text, or ``None`` if A-papero is unavailable.
+    """
+    try:
+        from A_papero.formats.pdf import read_pdf_bytes
+    except ImportError:
+        return None
+    return read_pdf_bytes(data)
+
+
 def _fmt_size(size: int) -> str:
     """Format byte count to human-readable string."""
     if size > 1024 * 1024:
@@ -113,6 +152,17 @@ def _print_text_attachment(svc: object, msg_uuid: str, att: dict) -> None:
         return
 
     # Truncation guard: if content is huge, print first and last N chars
+    _print_content_block(fname, raw, text)
+
+
+def _print_content_block(fname: str, raw: bytes, text: str) -> None:
+    """Print a content block with header and optional truncation.
+
+    Args:
+        fname: Attachment filename for the header.
+        raw: Raw bytes (for size calculation).
+        text: Decoded text content.
+    """
     MAX_STDOUT_CHARS = 50_000
     if len(text) > MAX_STDOUT_CHARS:
         info(f"--- {fname} ({_fmt_size(len(raw))}) — {tr_multi('montras unuajn', 'showing first', 'affiche les premiers')} {MAX_STDOUT_CHARS} {tr_multi('signojn', 'chars', 'caractères')} ---")
@@ -121,6 +171,48 @@ def _print_text_attachment(svc: object, msg_uuid: str, att: dict) -> None:
     else:
         info(f"--- {fname} ({_fmt_size(len(raw))}) ---")
         info(text)
+
+
+def _print_extracted_attachment(svc: object, msg_uuid: str, att: dict) -> None:
+    """Fetch an extractable-binary attachment (e.g. PDF) and print its text.
+
+    Requires ``A-papero[pdf]`` at runtime.  If unavailable, prints an
+    installation hint instead.
+
+    Args:
+        svc: RetpostoService instance.
+        msg_uuid: Message UUID.
+        att: Attachment metadata dict.
+    """
+    fname = att.get("dosiernomo", "?")
+    mime = att.get("mime_tipo", "") or "application/octet-stream"
+
+    try:
+        raw: bytes = svc.get_attachment_content(msg_uuid, fname)  # type: ignore[arg-type]
+    except Exception as e:
+        info(tr_multi(
+            f"  [eraro] {fname}: {e}",
+            f"  [error] {fname}: {e}",
+            f"  [erreur] {fname} : {e}",
+        ))
+        return
+
+    text = _try_extract_pdf_text(raw)
+    if text is None:
+        # A-papero not installed
+        info(tr_multi(
+            f"--- {fname} ({mime}) ---",
+            f"--- {fname} ({mime}) ---",
+            f"--- {fname} ({mime}) ---",
+        ))
+        info(tr_multi(
+            "Por eltiri tekston el PDF, instalu: pip install A-papero[pdf]",
+            "To extract text from PDF, install: pip install A-papero[pdf]",
+            "Pour extraire le texte du PDF, installez : pip install A-papero[pdf]",
+        ))
+        return
+
+    _print_content_block(fname, raw, text)
 
 
 # ── Main command ─────────────────────────────────────────────────────────────
@@ -201,6 +293,8 @@ def retposto_elsuti(
             mime = att.get("mime_tipo", "") or "application/octet-stream"
             if _is_text_mime(mime):
                 _print_text_attachment(svc, msg["uuid"], att)
+            elif _is_extractable_binary(mime):
+                _print_extracted_attachment(svc, msg["uuid"], att)
             else:
                 info(tr_multi(
                     f"[binary] {filename} ({mime}) — ne eblas montri kiel teksto; uzu --output por konservi",
@@ -211,6 +305,7 @@ def retposto_elsuti(
 
         # All attachments in stdout mode
         text_count = 0
+        extracted_count = 0
         binary_count = 0
         for att in attachments:
             fname = att.get("dosiernomo", "?")
@@ -218,6 +313,9 @@ def retposto_elsuti(
             if _is_text_mime(mime):
                 _print_text_attachment(svc, msg["uuid"], att)
                 text_count += 1
+            elif _is_extractable_binary(mime):
+                _print_extracted_attachment(svc, msg["uuid"], att)
+                extracted_count += 1
             else:
                 info(tr_multi(
                     f"--- {fname} ({mime}) — [binary] ne montrebla kiel teksto ---",
@@ -231,6 +329,12 @@ def retposto_elsuti(
                 f"Montris {text_count} tekstan(j)n aldona\u0135o(j)n.",
                 f"Displayed {text_count} text attachment(s).",
                 f"{text_count} pi\u00e8ce(s) jointe(s) texte affich\u00e9e(s).",
+            ))
+        if extracted_count:
+            info(tr_multi(
+                f"Elsutis tekston el {extracted_count} aldona\u0135o(j) (PDF).",
+                f"Extracted text from {extracted_count} attachment(s) (PDF).",
+                f"Texte extrait de {extracted_count} pi\u00e8ce(s) jointe(s) (PDF).",
             ))
         if binary_count:
             info(tr_multi(

--- a/tests/test_elsuti.py
+++ b/tests/test_elsuti.py
@@ -237,9 +237,10 @@ class TestElsutiStdout:
         from A_lien.service import get_retposto_service
 
         svc = get_retposto_service()
+        # Use a non-extractable binary MIME type (ZIP, not PDF)
         attachments = [{
-            "dosiernomo": "chart.pdf",
-            "mime_tipo": "application/pdf",
+            "dosiernomo": "archive.zip",
+            "mime_tipo": "application/zip",
             "grandeco": 50_000,
         }]
 
@@ -254,7 +255,7 @@ class TestElsutiStdout:
         all_calls = [str(c[0][0]) for c in mock_info.call_args_list]
         combined = " ".join(all_calls)
         assert "binary" in combined.lower() or "binaire" in combined.lower()
-        assert "chart.pdf" in combined
+        assert "archive.zip" in combined
 
     def test_stdout_specific_filename(self):
         """--stdout with a specific filename should print that attachment."""
@@ -280,3 +281,105 @@ class TestElsutiStdout:
         all_calls = [str(c[0][0]) for c in mock_info.call_args_list]
         combined = " ".join(all_calls)
         assert "csv,data,here" in combined
+
+
+# ---------------------------------------------------------------------------
+# PDF extraction in --stdout mode
+# ---------------------------------------------------------------------------
+
+
+class TestElsutiStdoutPdf:
+    """Tests for PDF text extraction via elsuti --stdout."""
+
+    def test_pdf_attachment_detected_as_extractable(self):
+        """application/pdf should be recognised as extractable binary."""
+        from A_lien.cli.retposto_elsuti import _is_extractable_binary
+
+        assert _is_extractable_binary("application/pdf")
+        assert not _is_extractable_binary("application/zip")
+        assert not _is_extractable_binary("text/plain")
+        assert not _is_extractable_binary("image/jpeg")
+
+    def test_stdout_pdf_with_a_papero_installed(self):
+        """With A-papero available, PDF content should be extracted and printed."""
+        from A_lien.service import get_retposto_service
+
+        svc = get_retposto_service()
+        attachments = [{
+            "dosiernomo": "doc.pdf",
+            "mime_tipo": "application/pdf",
+            "grandeco": 500,
+        }]
+
+        # Simulate A-papero being importable
+        with patch.object(svc, "get_message", return_value={"uuid": "abc12345"}), \
+             patch.object(svc, "get_attachments", return_value=attachments), \
+             patch.object(svc, "get_attachment_content", return_value=b"fake pdf bytes"), \
+             patch("A_lien.cli.retposto_elsuti._try_extract_pdf_text",
+                   return_value="Extracted PDF text content."), \
+             patch("A_lien.cli.retposto_elsuti.info") as mock_info:
+
+            runner = CliRunner()
+            result = runner.invoke(app, ["retposto", "elsuti", "abc12345", "--stdout"])
+
+        assert result.exit_code == 0
+        all_calls = [str(c[0][0]) for c in mock_info.call_args_list]
+        combined = " ".join(all_calls)
+        assert "Extracted PDF text content" in combined
+        assert "doc.pdf" in combined
+
+    def test_stdout_pdf_without_a_papero(self):
+        """Without A-papero, show install hint instead of content."""
+        from A_lien.service import get_retposto_service
+
+        svc = get_retposto_service()
+        attachments = [{
+            "dosiernomo": "doc.pdf",
+            "mime_tipo": "application/pdf",
+            "grandeco": 500,
+        }]
+
+        with patch.object(svc, "get_message", return_value={"uuid": "abc12345"}), \
+             patch.object(svc, "get_attachments", return_value=attachments), \
+             patch.object(svc, "get_attachment_content", return_value=b"fake pdf bytes"), \
+             patch("A_lien.cli.retposto_elsuti._try_extract_pdf_text",
+                   return_value=None), \
+             patch("A_lien.cli.retposto_elsuti.info") as mock_info:
+
+            runner = CliRunner()
+            result = runner.invoke(app, ["retposto", "elsuti", "abc12345", "--stdout"])
+
+        assert result.exit_code == 0
+        all_calls = [str(c[0][0]) for c in mock_info.call_args_list]
+        combined = " ".join(all_calls)
+        assert "pip install" in combined.lower()
+        assert "A-papero" in combined or "papero" in combined
+
+    def test_stdout_pdf_single_filename(self):
+        """--stdout with a PDF filename should extract that specific attachment."""
+        from A_lien.service import get_retposto_service
+
+        svc = get_retposto_service()
+        attachments = [
+            {"dosiernomo": "notes.txt", "mime_tipo": "text/plain", "grandeco": 50},
+            {"dosiernomo": "report.pdf", "mime_tipo": "application/pdf", "grandeco": 500},
+        ]
+
+        with patch.object(svc, "get_message", return_value={"uuid": "abc12345"}), \
+             patch.object(svc, "get_attachments", return_value=attachments), \
+             patch.object(svc, "get_attachment_content", return_value=b"pdf content here"), \
+             patch("A_lien.cli.retposto_elsuti._try_extract_pdf_text",
+                   return_value="PDF text content"), \
+             patch("A_lien.cli.retposto_elsuti.info") as mock_info:
+
+            runner = CliRunner()
+            result = runner.invoke(app, [
+                "retposto", "elsuti", "abc12345", "report.pdf", "--stdout",
+            ])
+
+        assert result.exit_code == 0
+        all_calls = [str(c[0][0]) for c in mock_info.call_args_list]
+        combined = " ".join(all_calls)
+        assert "PDF text content" in combined
+        assert "report.pdf" in combined
+        assert "notes.txt" not in combined  # Should NOT include other attachments


### PR DESCRIPTION
## Summary

Enhance `elsuti --stdout` to extract text from PDF attachments inline, using A-papero's `read_pdf_bytes()` via runtime optional import. No disk I/O, no second tool call — the LLM gets decoded PDF text in one step.

## Changes

| File | Change |
|------|--------|
| `retposto_elsuti.py` | Add `_EXTRACTABLE_BINARY_MIMES`, `_is_extractable_binary()`, `_try_extract_pdf_text()`, `_print_extracted_attachment()`, `_print_content_block()`. Update dispatch logic to try extraction for binary types. |
| `test_elsuti.py` | 4 new PDF extraction tests, 1 updated (binary uses ZIP instead of PDF) |

## How it works

1. LLM calls `lien_retposto_elsuti(uuid, --stdout)`
2. Attachment is `application/pdf` → enters `_print_extracted_attachment()`
3. Fetches bytes via `get_attachment_content()` (no disk I/O)
4. Tries `from A_papero.formats.pdf import read_pdf_bytes` (runtime import)
5. If available: extracts text, prints with truncation guard
6. If unavailable: prints install hint (`pip install A-papero[pdf]`)

## Before vs After

| Step | Before (two-tool) | After (single tool) |
|------|-------------------|---------------------|
| 1 | elsuti → saves to /tmp/doc.pdf | elsuti --stdout → extracts PDF bytes |
| 2 | konverti /tmp/doc.pdf → extracts text | → decodes bytes to text |
| 3 | Returns text | Returns text |
| Turns | 2 LLM calls | 1 LLM call |
| Temp files | Yes | No |

## Tests

195 passed, 5 skipped (up from 191, +4 new)