### PR TITLE
fix: localize option flags to Esperanto

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,18 @@ A-lien combines two autish commands:
 
 This is intentional — they share the same SQLite database (`lien.db`) for contacts→email linking.
 
+## CLI Option Naming Exceptions
+
+Per the [workspace AGENTS.md](https://github.com/Ron-RONZZ-org/A-workspace/blob/main/AGENTS.md#options-flags), the following option names are exempt from the Esperanto requirement in A-lien:
+
+| Exemption | Flags | Rationale |
+|-----------|-------|-----------|
+| **RFC email headers** | `--from`, `--to`, `--cc`, `--bcc`, `--subject`, `--body` | These are RFC 5322 wire-format field names recognized universally. Translating them would reduce usability. |
+| **Format names** | `--html`, `--json` | Proper nouns / format identifiers. |
+| **Debug/technical** | `--debug-imap`, `--stdout` | Developer-only flags for internal diagnostics. |
+
+All other CLI option flags **must** be in Esperanto per the workspace convention.
+
 ## Architecture
 
 ```

--- a/src/A_lien/cli.py
+++ b/src/A_lien/cli.py
@@ -136,11 +136,11 @@ def konton_vidi(
 def konton_aldoni(
     retposto: str = typer.Option(..., "--retposto", "-r", help=tr_multi("Retpoŝta adreso", "Email address", "Adresse email")),
     nomo: str = typer.Option("", "--nomo", "-n", help=tr_multi("Vidiga nomo", "Display name", "Nom d'affichage")),
-    imap_servilo: str = typer.Option("", "--imap-server", help=tr_multi("IMAP servilo", "IMAP server", "Serveur IMAP")),
-    imap_haveno: int = typer.Option(993, "--imap-port", help=tr_multi("IMAP haveno", "IMAP port", "Port IMAP")),
-    smtp_servilo: str = typer.Option("", "--smtp-server", help=tr_multi("SMTP servilo", "SMTP server", "Serveur SMTP")),
-    smtp_haveno: int = typer.Option(587, "--smtp-port", help=tr_multi("SMTP haveno", "SMTP port", "Port SMTP")),
-    password: str = typer.Option(..., "--password", "-p", prompt=True, hide_input=True, help=tr_multi("Konto pasvorto", "Account password", "Mot de passe")),
+    imap_servilo: str = typer.Option("", "--imap-servilo", help=tr_multi("IMAP servilo", "IMAP server", "Serveur IMAP")),
+    imap_haveno: int = typer.Option(993, "--imap-pordo", help=tr_multi("IMAP haveno", "IMAP port", "Port IMAP")),
+    smtp_servilo: str = typer.Option("", "--smtp-servilo", help=tr_multi("SMTP servilo", "SMTP server", "Serveur SMTP")),
+    smtp_haveno: int = typer.Option(587, "--smtp-pordo", help=tr_multi("SMTP haveno", "SMTP port", "Port SMTP")),
+    password: str = typer.Option(..., "--pasvorto", "-p", prompt=True, hide_input=True, help=tr_multi("Konto pasvorto", "Account password", "Mot de passe")),
 ) -> None:
     """Add a new email account (password stored in system keyring)."""
     service = get_retposto_service()
@@ -198,7 +198,7 @@ def konton_forigi(
     )],
     force: bool = typer.Option(
         False,
-        "--force",
+        "--deviga",
         "-f",
         help=tr_multi(
             "Forigi sen konfirmo",
@@ -247,11 +247,11 @@ def konton_modifi(
     uuid: str = typer.Argument(..., help=tr_multi("Konto UUID", "Account UUID", "UUID compte")),
     retposto: str = typer.Option("", "--retposto", "-r", help=tr_multi("Retpoŝta adreso", "Email address", "Adresse email")),
     nomo: str = typer.Option("", "--nomo", "-n", help=tr_multi("Vidiga nomo", "Display name", "Nom d'affichage")),
-    imap_servilo: str = typer.Option("", "--imap-server", help=tr_multi("IMAP servilo", "IMAP server", "Serveur IMAP")),
-    imap_haveno: int = typer.Option(0, "--imap-port", help=tr_multi("IMAP haveno", "IMAP port", "Port IMAP")),
-    smtp_servilo: str = typer.Option("", "--smtp-server", help=tr_multi("SMTP servilo", "SMTP server", "Serveur SMTP")),
-    smtp_haveno: int = typer.Option(0, "--smtp-port", help=tr_multi("SMTP haveno", "SMTP port", "Port SMTP")),
-    password: str = typer.Option("", "--password", "-p", help=tr_multi("Nova pasvorto", "New password", "Nouveau mot de passe")),
+    imap_servilo: str = typer.Option("", "--imap-servilo", help=tr_multi("IMAP servilo", "IMAP server", "Serveur IMAP")),
+    imap_haveno: int = typer.Option(0, "--imap-pordo", help=tr_multi("IMAP haveno", "IMAP port", "Port IMAP")),
+    smtp_servilo: str = typer.Option("", "--smtp-servilo", help=tr_multi("SMTP servilo", "SMTP server", "Serveur SMTP")),
+    smtp_haveno: int = typer.Option(0, "--smtp-pordo", help=tr_multi("SMTP haveno", "SMTP port", "Port SMTP")),
+    password: str = typer.Option("", "--pasvorto", "-p", help=tr_multi("Nova pasvorto", "New password", "Nouveau mot de passe")),
 ) -> None:
     """Modify an existing email account."""
     service = get_retposto_service()
@@ -339,11 +339,11 @@ def retposto_vidi(uuid: str = typer.Argument(..., help="Account UUID")) -> None:
 def retposto_aldoni_konton(
     retposto: str = typer.Option(..., "--retposto", "-r", help="Email address"),
     nomo: str = typer.Option("", "--nomo", "-n", help="Display name"),
-    imap_servilo: str = typer.Option("", "--imap-server", help="IMAP server"),
-    imap_haveno: int = typer.Option(993, "--imap-port", help="IMAP port"),
-    smtp_servilo: str = typer.Option("", "--smtp-server", help="SMTP server"),
-    smtp_haveno: int = typer.Option(587, "--smtp-port", help="SMTP port"),
-    password: str = typer.Option(..., "--password", "-p", prompt=True, hide_input=True, help="Account password"),
+    imap_servilo: str = typer.Option("", "--imap-servilo", help="IMAP server"),
+    imap_haveno: int = typer.Option(993, "--imap-pordo", help="IMAP port"),
+    smtp_servilo: str = typer.Option("", "--smtp-servilo", help="SMTP server"),
+    smtp_haveno: int = typer.Option(587, "--smtp-pordo", help="SMTP port"),
+    password: str = typer.Option(..., "--pasvorto", "-p", prompt=True, hide_input=True, help="Account password"),
 ) -> None:
     """[DEPRECATED] Use 'A lien retposto konton aldoni' instead."""
     konton_aldoni(retposto, nomo, imap_servilo, imap_haveno, smtp_servilo, smtp_haveno, password)
@@ -359,8 +359,8 @@ def retposto_forigi_konton(
 
 @retposto.command("preni")
 def retposto_preni(
-    account: str = typer.Option("", "--account", "-a", help=tr_multi("Specifa konto UUID", "Specific account UUID", "UUID compte spécifique")),
-    all_accounts: bool = typer.Option(False, "--all", help=tr_multi("Sinkronigi ĉiujn kontojn", "Sync all accounts", "Synchroniser tous les comptes")),
+    account: str = typer.Option("", "--konto", "-a", help=tr_multi("Specifa konto UUID", "Specific account UUID", "UUID compte spécifique")),
+    all_accounts: bool = typer.Option(False, "--chiuj", help=tr_multi("Sinkronigi ĉiujn kontojn", "Sync all accounts", "Synchroniser tous les comptes")),
 ) -> None:
     """Fetch mail from accounts."""
     svc = get_retposto_service()
@@ -415,8 +415,8 @@ def retposto_sendi(
     subject: str = typer.Option("", "--subject", "-s", help=tr_multi("Temeto", "Subject", "Sujet")),
     body: str = typer.Option("", "--body", "-b", help=tr_multi("Teksto de la mesaĝo", "Body text", "Corps du texte")),
     cc: str = typer.Option("", "--cc", help=tr_multi("KK (punktokomo-separita)", "CC (comma-separated)", "CC (séparé par;)")),
-    account: str = typer.Option("", "--account", "-a", help=tr_multi("Konto UUID", "Account UUID", "UUID compte")),
-    attach: list[str] = typer.Option([], "--attach", help=tr_multi("Dosiero algluenda", "File to attach", "Fichier à joindre")),
+    account: str = typer.Option("", "--konto", "-a", help=tr_multi("Konto UUID", "Account UUID", "UUID compte")),
+    attach: list[str] = typer.Option([], "--alglui", help=tr_multi("Dosiero algluenda", "File to attach", "Fichier à joindre")),
 ) -> None:
     """Send an email."""
     svc = get_retposto_service()

--- a/src/A_lien/cli/filtraj.py
+++ b/src/A_lien/cli/filtraj.py
@@ -27,7 +27,7 @@ filtraj_app = typer.Typer(
 @filtraj_app.command("ls")
 def filtraj_ls(
     account: str = typer.Option(
-        ..., "--account", "-a",
+        ..., "--konto", "-a",
         help=tr_multi("Konto UUID", "Account UUID", "UUID compte"),
     ),
 ) -> None:
@@ -60,7 +60,7 @@ def filtraj_ls(
 @filtraj_app.command("vidi")
 def filtraj_vidi(
     account: str = typer.Option(
-        ..., "--account", "-a",
+        ..., "--konto", "-a",
         help=tr_multi("Konto UUID", "Account UUID", "UUID compte"),
     ),
     name: str = typer.Argument(
@@ -84,7 +84,7 @@ def filtraj_vidi(
 @filtraj_app.command("aldoni")
 def filtraj_aldoni(
     account: str = typer.Option(
-        ..., "--account", "-a",
+        ..., "--konto", "-a",
         help=tr_multi("Konto UUID", "Account UUID", "UUID compte"),
     ),
     path: str = typer.Argument(
@@ -162,7 +162,7 @@ def filtraj_aldoni(
 @filtraj_app.command("forigi")
 def filtraj_forigi(
     account: str = typer.Option(
-        ..., "--account", "-a",
+        ..., "--konto", "-a",
         help=tr_multi("Konto UUID", "Account UUID", "UUID compte"),
     ),
     name: str = typer.Argument(
@@ -188,7 +188,7 @@ def filtraj_forigi(
 @filtraj_app.command("aktivi")
 def filtraj_aktivi(
     account: str = typer.Option(
-        ..., "--account", "-a",
+        ..., "--konto", "-a",
         help=tr_multi("Konto UUID", "Account UUID", "UUID compte"),
     ),
     name: str = typer.Argument(

--- a/src/A_lien/cli/kontakto.py
+++ b/src/A_lien/cli/kontakto.py
@@ -58,7 +58,7 @@ kontakto.add_typer(kategorio_app, name="kategorio")
 @kontakto.command("ls")
 def kontakto_ls(
     limit: int = typer.Option(
-        50, "--limit", "-l",
+        50, "--limo", "-l",
         help=tr_multi("Maksimumaj rezultoj", "Max results", "Résultats max"),
     ),
     order_by: str = typer.Option(
@@ -122,7 +122,7 @@ def kontakto_serci(
         help=tr_multi("Ŝalti fuzzy kongruigon", "Enable fuzzy matching", "Activer correspondance floue"),
     ),
     limit: int = typer.Option(
-        50, "--limit", "-l",
+        50, "--limo", "-l",
         help=tr_multi("Maksimumaj rezultoj", "Max results", "Résultats max"),
     ),
 ) -> None:

--- a/src/A_lien/cli/kontakto_edit.py
+++ b/src/A_lien/cli/kontakto_edit.py
@@ -377,7 +377,7 @@ def kontakto_eksporti(
         help=tr_multi("Eksporti unu kontakton", "Export single contact", "Exporter un contact"),
     ),
     output: str = typer.Option(
-        "", "--output", "-o",
+        "", "--eligo", "-o",
         help=tr_multi("Eliga dosiera vojo", "Output file path", "Chemin de sortie"),
     ),
 ) -> None:

--- a/src/A_lien/cli/konton.py
+++ b/src/A_lien/cli/konton.py
@@ -105,19 +105,19 @@ def konton_aldoni(
         help=tr_multi("Vidiga nomo", "Display name", "Nom d'affichage"),
     ),
     imap_servilo: str = typer.Option(
-        "", "--imap-server",
+        "", "--imap-servilo",
         help=tr_multi("IMAP servilo", "IMAP server", "Serveur IMAP"),
     ),
     imap_haveno: int = typer.Option(
-        993, "--imap-port",
+        993, "--imap-pordo",
         help=tr_multi("IMAP haveno", "IMAP port", "Port IMAP"),
     ),
     smtp_servilo: str = typer.Option(
-        "", "--smtp-server",
+        "", "--smtp-servilo",
         help=tr_multi("SMTP servilo", "SMTP server", "Serveur SMTP"),
     ),
     smtp_haveno: int = typer.Option(
-        587, "--smtp-port",
+        587, "--smtp-pordo",
         help=tr_multi("SMTP haveno", "SMTP port", "Port SMTP"),
     ),
     subskribo: str = typer.Option(
@@ -129,7 +129,7 @@ def konton_aldoni(
         ),
     ),
     password: str = typer.Option(
-        ..., "--password", "-p", prompt=True, hide_input=True,
+        ..., "--pasvorto", "-p", prompt=True, hide_input=True,
         help=tr_multi("Konto pasvorto", "Account password", "Mot de passe"),
     ),
 ) -> None:
@@ -202,7 +202,7 @@ def konton_forigi(
     )],
     force: bool = typer.Option(
         False,
-        "--force", "-f",
+        "--deviga", "-f",
         help=tr_multi(
             "Forigi sen konfirmo",
             "Delete without confirmation",
@@ -261,19 +261,19 @@ def konton_modifi(
         help=tr_multi("Vidiga nomo", "Display name", "Nom d'affichage"),
     ),
     imap_servilo: str = typer.Option(
-        "", "--imap-server",
+        "", "--imap-servilo",
         help=tr_multi("IMAP servilo", "IMAP server", "Serveur IMAP"),
     ),
     imap_haveno: int = typer.Option(
-        0, "--imap-port",
+        0, "--imap-pordo",
         help=tr_multi("IMAP haveno", "IMAP port", "Port IMAP"),
     ),
     smtp_servilo: str = typer.Option(
-        "", "--smtp-server",
+        "", "--smtp-servilo",
         help=tr_multi("SMTP servilo", "SMTP server", "Serveur SMTP"),
     ),
     smtp_haveno: int = typer.Option(
-        0, "--smtp-port",
+        0, "--smtp-pordo",
         help=tr_multi("SMTP haveno", "SMTP port", "Port SMTP"),
     ),
     subskribo: str = typer.Option(
@@ -285,7 +285,7 @@ def konton_modifi(
         ),
     ),
     password: str = typer.Option(
-        "", "--password", "-p",
+        "", "--pasvorto", "-p",
         help=tr_multi("Nova pasvorto", "New password", "Nouveau mot de passe"),
     ),
 ) -> None:

--- a/src/A_lien/cli/retposto_elsuti.py
+++ b/src/A_lien/cli/retposto_elsuti.py
@@ -234,7 +234,7 @@ def retposto_elsuti(
         ),
     ),
     output_dir: Optional[str] = typer.Option(
-        None, "--output", "-o",
+        None, "--eligo", "-o",
         help=tr_multi(
             "Konserva dosierujo (default: /tmp/)",
             "Output directory (default: /tmp/)",

--- a/src/A_lien/cli/retposto_search.py
+++ b/src/A_lien/cli/retposto_search.py
@@ -113,7 +113,7 @@ def retposto_serci(
         ),
     ),
     output: Optional[str] = typer.Option(
-        None, "--output", "-o",
+        None, "--eligo", "-o",
         help=tr_multi(
             "Eliga dosiero (anstataŭ stdout)",
             "Output file (instead of stdout)",

--- a/src/A_lien/cli/spamo.py
+++ b/src/A_lien/cli/spamo.py
@@ -87,7 +87,7 @@ def spamo_aldoni(
         ),
     ),
     account: str = typer.Option(
-        "", "--account", "-a",
+        "", "--konto", "-a",
         help=tr_multi(
             "Konto UUID por Sieve-sinkronigo",
             "Account UUID for Sieve sync",
@@ -135,7 +135,7 @@ def spamo_forigi(
         ),
     )],
     account: str = typer.Option(
-        "", "--account", "-a",
+        "", "--konto", "-a",
         help=tr_multi(
             "Konto UUID por Sieve-sinkronigo",
             "Account UUID for Sieve sync",
@@ -175,7 +175,7 @@ def spamo_forigi(
 @spamo_app.command("sinkronigi")
 def spamo_sinkronigi(
     account: str = typer.Option(
-        ..., "--account", "-a",
+        ..., "--konto", "-a",
         help=tr_multi(
             "Konto UUID por Sieve-sinkronigo",
             "Account UUID for Sieve sync",

--- a/tests/test_sendi_cli.py
+++ b/tests/test_sendi_cli.py
@@ -71,10 +71,10 @@ class TestKontonAldoniSubskribo:
         result = _run([
             "retposto", "konton", "aldoni",
             "--retposto", "alice@test.com",
-            "--imap-server", "imap.test.com",
-            "--smtp-server", "smtp.test.com",
+            "--imap-servilo", "imap.test.com",
+            "--smtp-servilo", "smtp.test.com",
             "--subskribo", "My Sig",
-            "--password", "pw",
+            "--pasvorto", "pw",
         ])
         assert result.exit_code == 0
         # Verify stored UUID
@@ -88,10 +88,10 @@ class TestKontonAldoniSubskribo:
         result = _run([
             "retposto", "konton", "aldoni",
             "--retposto", "bob@test.com",
-            "--imap-server", "imap.test.com",
-            "--smtp-server", "smtp.test.com",
+            "--imap-servilo", "imap.test.com",
+            "--smtp-servilo", "smtp.test.com",
             "--subskribo", "Nonexistent",
-            "--password", "pw",
+            "--pasvorto", "pw",
         ])
         assert result.exit_code == 1
         assert "ne trovita" in result.stdout or "not found" in result.stdout


### PR DESCRIPTION
P0 option flag renames across 9 files:\n- --account -> --konto (6 occurrences)\n- --attach -> --alglui\n- --all -> --chiuj\n- --force -> --deviga\n- --password -> --pasvorto\n- --limit -> --limo\n- --output -> --eligo\n- --imap-server/pord -> --imap-servilo/pordo\n- --smtp-server/port -> --smtp-servilo/pordo\n\nRFC email fields (--from, --to, --cc, --bcc, --subject, --body) exempted per workspace AGENTS.md.\n\nPart of systematic eo locale enforcement across the A-ecosystem.